### PR TITLE
Setup CI

### DIFF
--- a/.github/workflows/build-and-test.sh
+++ b/.github/workflows/build-and-test.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+set -ev
+
+export COLCON_WS=~/ws
+export COLCON_WS_SRC=${COLCON_WS}/src
+export DEBIAN_FRONTEND=noninteractive
+export ROS_PYTHON_VERSION=3
+
+mkdir -p $COLCON_WS_SRC
+
+apt update -qq
+apt install -qq -y lsb-release wget curl build-essential
+
+echo "deb http://packages.ros.org/ros2/ubuntu `lsb_release -cs` main" > /etc/apt/sources.list.d/ros2-latest.list
+curl -s https://raw.githubusercontent.com/ros/rosdistro/master/ros.asc | apt-key add -
+apt-get update -qq
+apt-get install -y git \
+                   python3-colcon-common-extensions \
+                   python3-rosdep \
+                   python3-vcstool \
+                   wget
+
+cd $COLCON_WS_SRC
+cp -r $GITHUB_WORKSPACE $COLCON_WS_SRC
+wget https://raw.githubusercontent.com/osrf/buoy_entrypoint/main/buoy_all.yaml
+vcs import < buoy_all.yaml
+
+rosdep init
+rosdep update
+rosdep install --from-paths ./ -i -y -r --rosdistro $ROS_DISTRO
+
+# Build.
+source /opt/ros/$ROS_DISTRO/setup.bash
+cd $COLCON_WS
+colcon build --event-handlers console_direct+
+
+# Tests.
+colcon test --event-handlers console_direct+
+colcon test-result

--- a/.github/workflows/build-and-test.sh
+++ b/.github/workflows/build-and-test.sh
@@ -29,11 +29,11 @@ rosdep init
 rosdep update
 rosdep install --from-paths ./ -i -y -r --rosdistro $ROS_DISTRO
 
-# Build.
+# Build everything up to buoy_gazebo
 source /opt/ros/$ROS_DISTRO/setup.bash
 cd $COLCON_WS
-colcon build --event-handlers console_direct+
+colcon build --packages-up-to buoy_gazebo --event-handlers console_direct+
 
-# Tests.
-colcon test --event-handlers console_direct+
+# Test all buoy packages
+colcon test --packages-select-regex=buoy --event-handlers console_direct+
 colcon test-result

--- a/.github/workflows/build-and-test.sh
+++ b/.github/workflows/build-and-test.sh
@@ -23,7 +23,7 @@ apt-get install -y git \
 cd $COLCON_WS_SRC
 cp -r $GITHUB_WORKSPACE $COLCON_WS_SRC
 wget https://raw.githubusercontent.com/osrf/buoy_entrypoint/main/buoy_all.yaml
-vcs import < buoy_all.yaml
+vcs import --skip-existing < buoy_all.yaml
 
 rosdep init
 rosdep update

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,23 @@
+name: Build and test
+
+on: [push, pull_request]
+
+jobs:
+  tests:
+    name: Build and test
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - gz-version: "fortress"
+            ros-distro: "galactic"
+    container:
+      image: ubuntu:latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Build and Test
+        run: .github/workflows/build-and-test.sh
+        env:
+          IGNITION_VERSION: ${{ matrix.gz-version  }}
+          ROS_DISTRO: ${{ matrix.ros-distro }}

--- a/buoy_gazebo/package.xml
+++ b/buoy_gazebo/package.xml
@@ -10,8 +10,9 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 
-  <depend>buoy_msgs</depend>
+  <depend>buoy_description</depend>
   <depend>buoy_examples</depend>
+  <depend>buoy_msgs</depend>
   <depend>ignition-gazebo6</depend>
   <depend>ros_ign_gazebo</depend>
 


### PR DESCRIPTION
Add GitHub actions-based CI that runs on every push and PR.

It uses binaries for ROS and Gazebo dependencies, pulled from https://packages.ros.org, and compiles from source all the repos in [buoy_all.yaml](https://github.com/osrf/buoy_entrypoint/blob/main/buoy_all.yaml). 

Then it tests all buoy repos, including `buoy_msgs`. I think we should just rely on the ROS buildfarm to run CI for the messages package eventually, but until we're ready to bloom it, we can test it here.

CI is currently failing the copyright check, which should be fixed by #6 