### PR TITLE
Remove default plugins from SDF worlds

### DIFF
--- a/buoy_gazebo/worlds/electrohydraulicPTO.sdf
+++ b/buoy_gazebo/worlds/electrohydraulicPTO.sdf
@@ -1,84 +1,11 @@
 <?xml version="1.0" ?>
 <sdf version="1.8">
     <world name="world_demo">
-    
+
         <physics name="1ms" type="ignored">
             <max_step_size>.001</max_step_size>
             <real_time_factor>1.0</real_time_factor>
         </physics>
-
-        <plugin filename="libignition-gazebo-physics-system.so" name="ignition::gazebo::systems::Physics">
-            <engine>"libignition-physics-dartsim-plugin.so"</engine> 
-        </plugin>
-
-        <plugin filename="libignition-gazebo-user-commands-system.so" name="ignition::gazebo::systems::UserCommands"/>
-        <plugin filename="libignition-gazebo-scene-broadcaster-system.so" name="ignition::gazebo::systems::SceneBroadcaster"/>
-        
-        <gui fullscreen="0">
-        
-            <!-- 3D scene -->
-            <plugin filename="GzScene3D" name="3D View">
-                <ignition-gui>
-                    <title>3D View</title>
-                    <property key="showTitleBar" type="bool">false</property>
-                    <property key="state" type="string">docked</property>
-                </ignition-gui>
-        
-                <engine>ogre</engine>
-                <scene>scene</scene>
-                <ambient_light>1.0 1.0 1.0</ambient_light>
-                <background_color>0.8 0.8 0.8</background_color>
-                <camera_pose>-6 0 6 0 0.5 0</camera_pose>
-            </plugin>
-        
-            <!-- World control -->
-            <plugin filename="WorldControl" name="World control">
-                <ignition-gui>
-                    <title>World control</title>
-                    <property key="showTitleBar" type="bool">false</property>
-                    <property key="resizable" type="bool">false</property>
-                    <property key="height" type="double">72</property>
-                    <property key="width" type="double">121</property>
-                    <property key="z" type="double">1</property>
-                    <property key="state" type="string">floating</property>
-                    <anchors target="3D View">
-                        <line own="left" target="left"/>
-                        <line own="bottom" target="bottom"/>
-                    </anchors>
-                </ignition-gui>
-        
-                <play_pause>true</play_pause>
-                <step>true</step>
-                <start_paused>true</start_paused>
-                <service>/world/world_demo/control</service>
-                <stats_topic>/world/world_demo/stats</stats_topic>
-            </plugin>
-        
-            <!-- World statistics -->
-            <plugin filename="WorldStats" name="World stats">
-                <ignition-gui>
-                    <title>World stats</title>
-                    <property key="showTitleBar" type="bool">false</property>
-                    <property key="resizable" type="bool">false</property>
-                    <property key="height" type="double">110</property>
-                    <property key="width" type="double">290</property>
-                    <property key="z" type="double">1</property>
-                    <property key="state" type="string">floating</property>
-                    <anchors target="3D View">
-                        <line own="right" target="right"/>
-                        <line own="bottom" target="bottom"/>
-                    </anchors>
-                </ignition-gui>
-                <sim_time>true</sim_time>
-                <real_time>true</real_time>
-                <real_time_factor>true</real_time_factor>
-                <iterations>true</iterations>
-                <topic>/world/world_demo/stats</topic>
-            </plugin>
-
-            <!-- Entity tree -->
-            <plugin filename="EntityTree" name="Entity tree"/>
-        </gui>
 
         <light name="sun" type="directional">
             <cast_shadows>true</cast_shadows>

--- a/buoy_gazebo/worlds/mbari_wec.sdf
+++ b/buoy_gazebo/worlds/mbari_wec.sdf
@@ -7,79 +7,6 @@
       <real_time_factor>1.0</real_time_factor>
     </physics>
 
-    <plugin filename="libignition-gazebo-physics-system.so" name="ignition::gazebo::systems::Physics">
-      <engine>"libignition-physics-dartsim-plugin.so"</engine> 
-    </plugin>
-
-    <plugin filename="libignition-gazebo-user-commands-system.so" name="ignition::gazebo::systems::UserCommands"/>
-    <plugin filename="libignition-gazebo-scene-broadcaster-system.so" name="ignition::gazebo::systems::SceneBroadcaster"/>
-
-    <gui fullscreen="0">
-
-      <!-- 3D scene -->
-      <plugin filename="GzScene3D" name="3D View">
-        <ignition-gui>
-          <title>3D View</title>
-          <property key="showTitleBar" type="bool">false</property>
-          <property key="state" type="string">docked</property>
-        </ignition-gui>
-
-        <engine>ogre</engine>
-        <scene>scene</scene>
-        <ambient_light>1.0 1.0 1.0</ambient_light>
-        <background_color>0.8 0.8 0.8</background_color>
-        <camera_pose>-6 0 6 0 0.5 0</camera_pose>
-      </plugin>
-
-      <!-- World control -->
-      <plugin filename="WorldControl" name="World control">
-        <ignition-gui>
-          <title>World control</title>
-          <property key="showTitleBar" type="bool">false</property>
-          <property key="resizable" type="bool">false</property>
-          <property key="height" type="double">72</property>
-          <property key="width" type="double">121</property>
-          <property key="z" type="double">1</property>
-          <property key="state" type="string">floating</property>
-          <anchors target="3D View">
-            <line own="left" target="left"/>
-            <line own="bottom" target="bottom"/>
-          </anchors>
-        </ignition-gui>
-
-        <play_pause>true</play_pause>
-        <step>true</step>
-        <start_paused>true</start_paused>
-        <service>/world/world_demo/control</service>
-        <stats_topic>/world/world_demo/stats</stats_topic>
-      </plugin>
-
-      <!-- World statistics -->
-      <plugin filename="WorldStats" name="World stats">
-        <ignition-gui>
-          <title>World stats</title>
-          <property key="showTitleBar" type="bool">false</property>
-          <property key="resizable" type="bool">false</property>
-          <property key="height" type="double">110</property>
-          <property key="width" type="double">290</property>
-          <property key="z" type="double">1</property>
-          <property key="state" type="string">floating</property>
-          <anchors target="3D View">
-            <line own="right" target="right"/>
-            <line own="bottom" target="bottom"/>
-          </anchors>
-        </ignition-gui>
-        <sim_time>true</sim_time>
-        <real_time>true</real_time>
-        <real_time_factor>true</real_time_factor>
-        <iterations>true</iterations>
-        <topic>/world/world_demo/stats</topic>
-      </plugin>
-
-        <!-- Entity tree -->
-      <plugin filename="EntityTree" name="Entity tree"/>
-    </gui>
-
     <light name="sun" type="directional">
       <cast_shadows>true</cast_shadows>
       <pose>0 0 10 0 0 0</pose>
@@ -225,7 +152,7 @@
           </limit>
           <xyz>0.0 0.0 1.0</xyz>
           <dynamics>
-            <spring_stiffness>55000</spring_stiffness>  
+            <spring_stiffness>55000</spring_stiffness>
             <spring_reference>0.0</spring_reference>
             <damping>1000.0</damping>
             <friction>0.0</friction>

--- a/buoy_gazebo/worlds/pneumatic_spring.sdf
+++ b/buoy_gazebo/worlds/pneumatic_spring.sdf
@@ -7,79 +7,6 @@
             <real_time_factor>1.0</real_time_factor>
         </physics>
 
-        <plugin filename="libignition-gazebo-physics-system.so" name="ignition::gazebo::systems::Physics">
-            <engine>"libignition-physics-dartsim-plugin.so"</engine>
-        </plugin>
-
-        <plugin filename="libignition-gazebo-user-commands-system.so" name="ignition::gazebo::systems::UserCommands"/>
-        <plugin filename="libignition-gazebo-scene-broadcaster-system.so" name="ignition::gazebo::systems::SceneBroadcaster"/>
-        
-        <gui fullscreen="0">
-
-            <!-- 3D scene -->
-            <plugin filename="GzScene3D" name="3D View">
-                <ignition-gui>
-                    <title>3D View</title>
-                    <property key="showTitleBar" type="bool">false</property>
-                    <property key="state" type="string">docked</property>
-                </ignition-gui>
-
-                <engine>ogre</engine>
-                <scene>scene</scene>
-                <ambient_light>1.0 1.0 1.0</ambient_light>
-                <background_color>0.8 0.8 0.8</background_color>
-                <camera_pose>-6 0 6 0 0.5 0</camera_pose>
-            </plugin>
-
-            <!-- World control -->
-            <plugin filename="WorldControl" name="World control">
-                <ignition-gui>
-                    <title>World control</title>
-                    <property key="showTitleBar" type="bool">false</property>
-                    <property key="resizable" type="bool">false</property>
-                    <property key="height" type="double">72</property>
-                    <property key="width" type="double">121</property>
-                    <property key="z" type="double">1</property>
-                    <property key="state" type="string">floating</property>
-                    <anchors target="3D View">
-                        <line own="left" target="left"/>
-                        <line own="bottom" target="bottom"/>
-                    </anchors>
-                </ignition-gui>
-
-                <play_pause>true</play_pause>
-                <step>true</step>
-                <start_paused>true</start_paused>
-                <service>/world/world_demo/control</service>
-                <stats_topic>/world/world_demo/stats</stats_topic>
-            </plugin>
-
-            <!-- World statistics -->
-            <plugin filename="WorldStats" name="World stats">
-                <ignition-gui>
-                    <title>World stats</title>
-                    <property key="showTitleBar" type="bool">false</property>
-                    <property key="resizable" type="bool">false</property>
-                    <property key="height" type="double">110</property>
-                    <property key="width" type="double">290</property>
-                    <property key="z" type="double">1</property>
-                    <property key="state" type="string">floating</property>
-                    <anchors target="3D View">
-                        <line own="right" target="right"/>
-                        <line own="bottom" target="bottom"/>
-                    </anchors>
-                </ignition-gui>
-                <sim_time>true</sim_time>
-                <real_time>true</real_time>
-                <real_time_factor>true</real_time_factor>
-                <iterations>true</iterations>
-                <topic>/world/world_demo/stats</topic>
-            </plugin>
-
-            <!-- Entity tree -->
-            <plugin filename="EntityTree" name="Entity tree"/>
-        </gui>
-        
         <light name="sun" type="directional">
             <cast_shadows>true</cast_shadows>
             <pose>0 0 10 0 0 0</pose>
@@ -337,7 +264,7 @@
                 <P1>410291</P1>
                 <P2>410266</P2>
             </plugin>
-            
+
             <!-- <debug_prescribed_velocity>true</debug_prescribed_velocity>-->
             <plugin filename="PolytropicPneumaticSpring" name="ignition::gazebo::systems::PolytropicPneumaticSpring">
                 <JointName>joint_poly</JointName>


### PR DESCRIPTION
The SDF worlds are currently loading several world and GUI plugins which would be loaded by default anyway. We can reduce some boilerplate by just removing all plugins. We should only specify the plugins to load in case we want to load non-default plugins.

You can check that the world still work as before:

```
ign gazebo -v 2 mbari_wec.sdf
ign gazebo -v 2 electrohydraulicPTO.sdf
ign gazebo -v 2 pneumatic_spring.sdf
```