### PR TITLE
Use project-specific C++ namespaces

### DIFF
--- a/buoy_gazebo/src/ElectroHydraulicPTO/ElectroHydraulicPTO.cc
+++ b/buoy_gazebo/src/ElectroHydraulicPTO/ElectroHydraulicPTO.cc
@@ -41,29 +41,26 @@
 #include "JustInterp/JustInterp.hpp"
 #include "ElectroHydraulicSoln.hh"
 
-using namespace ignition;
-using namespace gazebo;
-using namespace systems;
-using namespace Eigen;
-
-class ignition::gazebo::systems::ElectroHydraulicPTOPrivate
+namespace buoy_gazebo
 {
 
-  /// \brief Piston joint entity
-public: Entity PrismaticJointEntity;
+class ElectroHydraulicPTOPrivate
+{
+/// \brief Piston joint entity
+public: ignition::gazebo::Entity PrismaticJointEntity;
 
-  /// \brief Piston area
+/// \brief Piston area
 public: double PistonArea;
 
-  /// \brief Rotor Inertia
+/// \brief Rotor Inertia
 public: double RotorInertia;
 
-  /// \brief Model interface
-public: Model model{kNullEntity};
+/// \brief Model interface
+public: ignition::gazebo::Model model{ignition::gazebo::kNullEntity};
 
 public: ElectroHydraulicSoln functor;
 
-public: VectorXd x;
+public: Eigen::VectorXd x;
 
 public: double TargetWindingCurrent;
 
@@ -73,26 +70,25 @@ public: double Ve;
 
 public: bool VelMode;
 
-  /// \brief Ignition communication node.
-public: transport::Node node;
+/// \brief Ignition communication node.
+public: ignition::transport::Node node;
 
-  /// \brief Callback for User Commanded Current subscription
-  /// \param[in] _msg Current
+/// \brief Callback for User Commanded Current subscription
+/// \param[in] _msg Current
 public: void OnUserCmdCurr(const ignition::msgs::Double &_msg);
 
-  /// \brief Callback for BiasCurrent subscription
-  /// \param[in] _msg Current
+/// \brief Callback for BiasCurrent subscription
+/// \param[in] _msg Current
 public: void OnUserBiasCurr(const ignition::msgs::Double &_msg);
 
-  /// \brief Callback for ScaleFactor subscription
-  /// \param[in] _msg Current
-public: void OnScale(const msgs::Double &_msg);
+/// \brief Callback for ScaleFactor subscription
+/// \param[in] _msg Current
+public: void OnScale(const ignition::msgs::Double &_msg);
 
-  /// \brief Callback for RetractFactor subscription
-  /// \param[in] _msg Current
-public: void OnRetract(const msgs::Double &_msg);
+/// \brief Callback for RetractFactor subscription
+/// \param[in] _msg Current
+public: void OnRetract(const ignition::msgs::Double &_msg);
 };
-
 
 //////////////////////////////////////////////////
 ElectroHydraulicPTO::ElectroHydraulicPTO()
@@ -112,12 +108,12 @@ double SdfParamDouble(
 
 
 //////////////////////////////////////////////////
-void ElectroHydraulicPTO::Configure(const Entity &_entity,
+void ElectroHydraulicPTO::Configure(const ignition::gazebo::Entity &_entity,
     const std::shared_ptr<const sdf::Element> &_sdf,
-    EntityComponentManager &_ecm,
-    EventManager &/*_eventMgr*/)
+    ignition::gazebo::EntityComponentManager &_ecm,
+    ignition::gazebo::EventManager &/*_eventMgr*/)
 {
-  this->dataPtr->model = Model(_entity);
+  this->dataPtr->model = ignition::gazebo::Model(_entity);
   if (!this->dataPtr->model.Valid(_ecm))
   {
     ignerr << "ElectroHydraulicPTO plugin should be attached to a model entity. "
@@ -138,7 +134,7 @@ void ElectroHydraulicPTO::Configure(const Entity &_entity,
 
   this->dataPtr->PrismaticJointEntity = this->dataPtr->model.JointByName(_ecm,
                                         PrismaticJointName);
-  if (this->dataPtr->PrismaticJointEntity == kNullEntity)
+  if (this->dataPtr->PrismaticJointEntity == ignition::gazebo::kNullEntity)
   {
     ignerr << "Joint with name [" << PrismaticJointName << "] not found. "
            << "The ElectroHydraulicPTO may not influence this joint.\n";
@@ -174,7 +170,7 @@ void ElectroHydraulicPTO::Configure(const Entity &_entity,
   this->dataPtr->x.setConstant(2, 0.);
 
   // Subscribe to commands
-  std::string topic = transport::TopicUtils::AsValidTopic("/model/" +
+  std::string topic = ignition::transport::TopicUtils::AsValidTopic("/model/" +
                       this->dataPtr->model.Name(_ecm) + "/joint/" + PrismaticJointName +
                       "/UserCommandedCurr");
   if (topic.empty())
@@ -189,7 +185,7 @@ void ElectroHydraulicPTO::Configure(const Entity &_entity,
             << "]" << std::endl;
 
 
-  topic = transport::TopicUtils::AsValidTopic("/model/" +
+  topic = ignition::transport::TopicUtils::AsValidTopic("/model/" +
           this->dataPtr->model.Name(_ecm) + "/joint/" + PrismaticJointName +
           "/BiasCurrent");
   if (topic.empty())
@@ -204,7 +200,7 @@ void ElectroHydraulicPTO::Configure(const Entity &_entity,
             << "]" << std::endl;
 
 
-  topic = transport::TopicUtils::AsValidTopic("/model/" +
+  topic = ignition::transport::TopicUtils::AsValidTopic("/model/" +
           this->dataPtr->model.Name(_ecm) + "/joint/" + PrismaticJointName +
           "/ScaleFactor");
   if (topic.empty())
@@ -219,7 +215,7 @@ void ElectroHydraulicPTO::Configure(const Entity &_entity,
             << "]" << std::endl;
 
 
-  topic = transport::TopicUtils::AsValidTopic("/model/" +
+  topic = ignition::transport::TopicUtils::AsValidTopic("/model/" +
           this->dataPtr->model.Name(_ecm) + "/joint/" + PrismaticJointName +
           "/RetractFactor");
   if (topic.empty())
@@ -327,7 +323,7 @@ void ElectroHydraulicPTO::PreUpdate(const ignition::gazebo::UpdateInfo &_info,
   IGN_PROFILE("#ElectroHydraulicPTO::PreUpdate");
 
   // If the joints haven't been identified yet, the plugin is disabled
-  if (this->dataPtr->PrismaticJointEntity == kNullEntity)
+  if (this->dataPtr->PrismaticJointEntity == ignition::gazebo::kNullEntity)
     return;
 
   // \TODO(anyone) Support rewind
@@ -341,11 +337,11 @@ void ElectroHydraulicPTO::PreUpdate(const ignition::gazebo::UpdateInfo &_info,
 
   // Create joint velocity component for piston if one doesn't exist
   auto prismaticJointVelComp =
-    _ecm.Component<components::JointVelocity>(this->dataPtr->PrismaticJointEntity);
+    _ecm.Component<ignition::gazebo::components::JointVelocity>(this->dataPtr->PrismaticJointEntity);
   if (prismaticJointVelComp == nullptr)
   {
     _ecm.CreateComponent(
-      this->dataPtr->PrismaticJointEntity, components::JointVelocity());
+      this->dataPtr->PrismaticJointEntity, ignition::gazebo::components::JointVelocity());
   }
   // We just created the joint velocity component, give one iteration for the
   // physics system to update its size
@@ -369,7 +365,7 @@ void ElectroHydraulicPTO::PreUpdate(const ignition::gazebo::UpdateInfo &_info,
   this->dataPtr->functor.I_Wind.UserCommandMutex.lock();  //Preclude changing User Commanded Current while it may be being read.
   //this->dataPtr->x[0] = 60*this->dataPtr->functor.Q/this->dataPtr->functor.HydMotorDisp; //Initial Guess based on perfect efficiency
   //this->dataPtr->x[1] = this->dataPtr->functor.T_applied/(this->dataPtr->functor.HydMotorDisp); //Initial Guess based on perfect efficiency
-  HybridNonLinearSolver<ElectroHydraulicSoln> solver(this->dataPtr->functor);
+  Eigen::HybridNonLinearSolver<ElectroHydraulicSoln> solver(this->dataPtr->functor);
   info = solver.solveNumericalDiff(this->dataPtr->x);
   //info = solver.hybrd1(this->dataPtr->x);
   this->dataPtr->functor.I_Wind.UserCommandMutex.unlock();
@@ -475,9 +471,9 @@ void ElectroHydraulicPTO::PreUpdate(const ignition::gazebo::UpdateInfo &_info,
 
 
 //Create new component for this entitiy in ECM (if it doesn't already exist)
-  auto PTO_State_comp = _ecm.Component<components::PTO_State>(this->dataPtr->PrismaticJointEntity);
+  auto PTO_State_comp = _ecm.Component<buoy_gazebo::PTO_State>(this->dataPtr->PrismaticJointEntity);
   if (PTO_State_comp == nullptr)
-    _ecm.CreateComponent(this->dataPtr->PrismaticJointEntity, components::PTO_State({PTO_Values}));
+    _ecm.CreateComponent(this->dataPtr->PrismaticJointEntity, buoy_gazebo::PTO_State({PTO_Values}));
   else
     PTO_State_comp->Data() = PTO_Values;
 
@@ -486,9 +482,9 @@ void ElectroHydraulicPTO::PreUpdate(const ignition::gazebo::UpdateInfo &_info,
   {
     double piston_force = deltaP * this->dataPtr->PistonArea;
 //Create new component for this entitiy in ECM (if it doesn't already exist)
-    auto forceComp = _ecm.Component<components::JointForceCmd>(this->dataPtr->PrismaticJointEntity);
+    auto forceComp = _ecm.Component<ignition::gazebo::components::JointForceCmd>(this->dataPtr->PrismaticJointEntity);
     if (forceComp == nullptr)
-      _ecm.CreateComponent(this->dataPtr->PrismaticJointEntity, components::JointForceCmd({piston_force}));  //Create this iteration
+      _ecm.CreateComponent(this->dataPtr->PrismaticJointEntity, ignition::gazebo::components::JointForceCmd({piston_force}));  //Create this iteration
     else
       forceComp->Data()[0] += piston_force;  //Add force to existing forces.
   }
@@ -520,35 +516,33 @@ void ElectroHydraulicPTO::PostUpdate(const ignition::gazebo::UpdateInfo &_info,
 
 
 //////////////////////////////////////////////////
-void ElectroHydraulicPTOPrivate::OnUserCmdCurr(const msgs::Double &_msg)
+void ElectroHydraulicPTOPrivate::OnUserCmdCurr(const ignition::msgs::Double &_msg)
 {
   this->functor.I_Wind.SetUserCommandedCurrent(_msg.data());
 }
 
 //////////////////////////////////////////////////
-void ElectroHydraulicPTOPrivate::OnUserBiasCurr(const msgs::Double &_msg)
+void ElectroHydraulicPTOPrivate::OnUserBiasCurr(const ignition::msgs::Double &_msg)
 {
   this->functor.I_Wind.SetBiasCurrent(_msg.data());
 }
 
 //////////////////////////////////////////////////
-void ElectroHydraulicPTOPrivate::OnScale(const msgs::Double &_msg)
+void ElectroHydraulicPTOPrivate::OnScale(const ignition::msgs::Double &_msg)
 {
   this->functor.I_Wind.SetScaleFactor(_msg.data());
 }
 
 //////////////////////////////////////////////////
-void ElectroHydraulicPTOPrivate::OnRetract(const msgs::Double &_msg)
+void ElectroHydraulicPTOPrivate::OnRetract(const ignition::msgs::Double &_msg)
 {
   this->functor.I_Wind.SetRetractFactor(_msg.data());
 }
+} // namespace buoy_gazebo
 
-IGNITION_ADD_PLUGIN(ElectroHydraulicPTO,
+IGNITION_ADD_PLUGIN(buoy_gazebo::ElectroHydraulicPTO,
                     ignition::gazebo::System,
-                    ElectroHydraulicPTO::ISystemConfigure,
-                    ElectroHydraulicPTO::ISystemPreUpdate,
-                    ElectroHydraulicPTO::ISystemUpdate,
-                    ElectroHydraulicPTO::ISystemPostUpdate);
-
-IGNITION_ADD_PLUGIN_ALIAS(ElectroHydraulicPTO,
-                          "ignition::gazebo::systems::ElectroHydraulicPTO")
+                    buoy_gazebo::ElectroHydraulicPTO::ISystemConfigure,
+                    buoy_gazebo::ElectroHydraulicPTO::ISystemPreUpdate,
+                    buoy_gazebo::ElectroHydraulicPTO::ISystemUpdate,
+                    buoy_gazebo::ElectroHydraulicPTO::ISystemPostUpdate);

--- a/buoy_gazebo/src/ElectroHydraulicPTO/ElectroHydraulicPTO.hh
+++ b/buoy_gazebo/src/ElectroHydraulicPTO/ElectroHydraulicPTO.hh
@@ -6,91 +6,76 @@
 #include <memory>
 #include <optional>
 
-namespace ignition
+namespace buoy_gazebo
 {
-namespace gazebo
+// enum class SpringType { linear, pneumatic_adiabatic, pneumatic_calibrated};
+
+// Forward declaration
+class ElectroHydraulicPTOPrivate;
+
+/// \brief To use, several parameters are required.
+/// Two ignition gazebo joints that are either prismatic or continous with 1DOF each, a desciption of
+/// the connectoins between actuator (joints), and an oil characteristic specification.
+///
+/// ## System Parameters
+///
+/// xml tags in Ignition Gazebo .sdf file define behavior as follows:
+///
+/// \brief <PrismaticJointName>
+///
+///  For each actuator of prismatic type, the following nested tags are required:
+///     <Area_A>  Piston area on A end of cylinder
+///
+///     <Area_B>  Piston area on B end of Cylinder
+///
+///
+/// \brief <RevoluteJointName>
+///   For each actuator of revolute type, the following nested tags are required:
+///
+///     <Displacement>  Displacement per revolution of rotary pump/motor.
+class ElectroHydraulicPTO
+    : public ignition::gazebo::System,
+      public ignition::gazebo::ISystemConfigure,
+      public ignition::gazebo::ISystemPreUpdate,
+      public ignition::gazebo::ISystemUpdate,
+      public ignition::gazebo::ISystemPostUpdate
 {
-// Inline bracket to help doxygen filtering.
-inline namespace IGNITION_GAZEBO_VERSION_NAMESPACE {
-namespace systems
-{
+  /// \brief Constructor
+  public: ElectroHydraulicPTO();
 
-   // enum class SpringType { linear, pneumatic_adiabatic, pneumatic_calibrated};
+  /// \brief Destructor
+  public: ~ElectroHydraulicPTO() override = default;
 
-  // Forward declaration
-  class ElectroHydraulicPTOPrivate;
+  // Documentation inherited
+  public: void Configure(const ignition::gazebo::Entity &_entity,
+                         const std::shared_ptr<const sdf::Element> &_sdf,
+                         ignition::gazebo::EntityComponentManager &_ecm,
+                         ignition::gazebo::EventManager &_eventMgr) override;
 
-  /// \brief To use, several parameters are required.  
-  /// Two ignition gazebo joints that are either prismatic or continous with 1DOF each, a desciption of 
-  /// the connectoins between actuator (joints), and an oil characteristic specification.
-  ///
-  /// ## System Parameters
-  ///
-  /// xml tags in Ignition Gazebo .sdf file define behavior as follows:
-  ///
-  /// \brief <PrismaticJointName>  
-  ///
-  ///  For each actuator of prismatic type, the following nested tags are required:
-  ///     <Area_A>  Piston area on A end of cylinder
-  ///
-  ///     <Area_B>  Piston area on B end of Cylinder
-  ///     
-  ///
-  /// \brief <RevoluteJointName>  
-  ///   For each actuator of revolute type, the following nested tags are required:
-  ///
-  ///     <Displacement>  Displacement per revolution of rotary pump/motor.
+  // Documentation inherited
+  public: void PreUpdate(
+              const ignition::gazebo::UpdateInfo &_info,
+              ignition::gazebo::EntityComponentManager &_ecm) override;
+
+  // Documentation inherited
+  public: void Update(
+              const ignition::gazebo::UpdateInfo &_info,
+              ignition::gazebo::EntityComponentManager &_ecm) override;
+
+  // Documentation inherited
+  public: void PostUpdate(
+              const ignition::gazebo::UpdateInfo &_info,
+              const ignition::gazebo::EntityComponentManager &_ecm) override;
 
 
+private:
+  ignition::transport::Node node;
+  ignition::transport::Node::Publisher pistonvel_pub, rpm_pub, deltaP_pub, targwindcurr_pub, windcurr_pub,
+                                       battcurr_pub, loadcurr_pub, scalefactor_pub, retractfactor_pub;
 
-
-
-  class ElectroHydraulicPTO
-      : public System,
-        public ISystemConfigure,
-        public ISystemPreUpdate,
-        public ISystemUpdate,
-        public ISystemPostUpdate 
-  {
-    /// \brief Constructor
-    public: ElectroHydraulicPTO();
-
-    /// \brief Destructor
-    public: ~ElectroHydraulicPTO() override = default;
-
-    // Documentation inherited
-    public: void Configure(const Entity &_entity,
-                           const std::shared_ptr<const sdf::Element> &_sdf,
-                           EntityComponentManager &_ecm,
-                           EventManager &_eventMgr) override;
-
-    // Documentation inherited
-    public: void PreUpdate(
-                const ignition::gazebo::UpdateInfo &_info,
-                ignition::gazebo::EntityComponentManager &_ecm) override;
-
-    // Documentation inherited
-    public: void Update(
-                const ignition::gazebo::UpdateInfo &_info,
-                ignition::gazebo::EntityComponentManager &_ecm) override;
-
-    // Documentation inherited
-    public: void PostUpdate(
-                const ignition::gazebo::UpdateInfo &_info,
-                const ignition::gazebo::EntityComponentManager &_ecm) override;
-
-
-private: 
-    ignition::transport::Node node;
-    ignition::transport::Node::Publisher pistonvel_pub, rpm_pub, deltaP_pub, targwindcurr_pub, windcurr_pub,
-                                         battcurr_pub, loadcurr_pub, scalefactor_pub, retractfactor_pub;
-
-    /// \brief Private data pointer
-    private: std::unique_ptr<ElectroHydraulicPTOPrivate> dataPtr;
-  };
-  }
-}
-}
-}
+  /// \brief Private data pointer
+  private: std::unique_ptr<ElectroHydraulicPTOPrivate> dataPtr;
+};
+} // namespace buoy_gazebo
 
 #endif

--- a/buoy_gazebo/src/ElectroHydraulicPTO/ElectroHydraulicSoln.hh
+++ b/buoy_gazebo/src/ElectroHydraulicPTO/ElectroHydraulicSoln.hh
@@ -30,11 +30,9 @@
 #include "WindingCurrentTarget.hh"
 
 
-using namespace Eigen;
-
 /////////////////////////////////////////////////////
 // Generic functor
-template<typename _Scalar, int NX=Dynamic, int NY=Dynamic>
+template<typename _Scalar, int NX=Eigen::Dynamic, int NY=Eigen::Dynamic>
 struct Functor
 {
   typedef _Scalar Scalar;
@@ -42,9 +40,9 @@ struct Functor
     InputsAtCompileTime = NX,
     ValuesAtCompileTime = NY
   };
-  typedef Matrix<Scalar,InputsAtCompileTime,1> InputType;
-  typedef Matrix<Scalar,ValuesAtCompileTime,1> ValueType;
-  typedef Matrix<Scalar,ValuesAtCompileTime,InputsAtCompileTime> JacobianType;
+  typedef Eigen::Matrix<Scalar,InputsAtCompileTime,1> InputType;
+  typedef Eigen::Matrix<Scalar,ValuesAtCompileTime,1> ValueType;
+  typedef Eigen::Matrix<Scalar,ValuesAtCompileTime,InputsAtCompileTime> JacobianType;
 
   const int m_inputs, m_values;
 
@@ -70,7 +68,7 @@ struct ElectroHydraulicSoln : Functor<double>
   /// \brief Pump/Motor Displacement per Revolution
   public: double HydMotorDisp;
 
-  ElectroHydraulicSoln(void) : Functor<double>(2,2) 
+  ElectroHydraulicSoln(void) : Functor<double>(2,2)
   {
   //Set Pressure versus flow relationship for relief valve
     {
@@ -148,8 +146,8 @@ struct ElectroHydraulicSoln : Functor<double>
     }
 
 //  x[0] = RPM
-//  x[1] = Pressure (psi)     
-    int operator()(const VectorXd &x, VectorXd &fvec) const
+//  x[1] = Pressure (psi)
+    int operator()(const Eigen::VectorXd &x, Eigen::VectorXd &fvec) const
     {
         const int n = x.size();
         assert(fvec.size()==n);
@@ -166,7 +164,7 @@ struct ElectroHydraulicSoln : Functor<double>
 
         fvec[0] = x[0]-eff_v*60.0*QQ/this->HydMotorDisp;
         fvec[1] = x[1]-eff_m*T_applied/(this->HydMotorDisp/(2*M_PI));
-       
+
         return 0;
     }
 };

--- a/buoy_gazebo/src/ElectroHydraulicPTO/ElectroHydraulicState.hh
+++ b/buoy_gazebo/src/ElectroHydraulicPTO/ElectroHydraulicState.hh
@@ -21,6 +21,9 @@
 #include <ignition/gazebo/components/Component.hh>
 #include <ignition/gazebo/config.hh>
 
+namespace buoy_gazebo
+{
+
 struct ElectroHydraulicState
 {
   double xdot;
@@ -38,26 +41,15 @@ struct ElectroHydraulicState
   double RPMStdDev;
   double BiasCurrent;
   short Status; //should be 16 bits...
-  
+
 };
 
-
-namespace ignition
-{
-namespace gazebo
-{
-// Inline bracket to help doxygen filtering.
-inline namespace IGNITION_GAZEBO_VERSION_NAMESPACE {
-namespace components
-{
-  /// \brief A volume component where the units are m^3.
-  /// Double value indicates volume of an entity.
-  using PTO_State = Component<ElectroHydraulicState, class ElectroHydraulicStateTag>;
-  IGN_GAZEBO_REGISTER_COMPONENT("ign_gazebo_components.PTO_State", PTO_State)
-}
-}
-}
-}
+/// \brief A volume component where the units are m^3.
+/// Double value indicates volume of an entity.
+using PTO_State =
+    ignition::gazebo::components::Component<ElectroHydraulicState, class ElectroHydraulicStateTag>;
+IGN_GAZEBO_REGISTER_COMPONENT("buoy_gazebo.PTO_State", PTO_State)
+} // namespace buoy_gazebo
 
 #endif
 

--- a/buoy_gazebo/src/PolytropicPneumaticSpring/PolytropicPneumaticSpring.hh
+++ b/buoy_gazebo/src/PolytropicPneumaticSpring/PolytropicPneumaticSpring.hh
@@ -22,87 +22,77 @@
 
 #include <ignition/transport.hh>
 
-namespace ignition
+namespace buoy_gazebo
 {
-namespace gazebo
+//enum class SpringType { linear, pneumatic_adiabatic, pneumatic_calibrated};
+
+// Forward declaration
+struct PolytropicPneumaticSpringPrivate;
+
+/// \brief This can be attached to a model with a reference
+/// to a single prismatic joint. A force proportional to the
+/// joint displacement will be applied along the axis of the joint.
+/// This is an added force that will sum to other forces that may be present.
+///
+/// ## System Parameters
+///
+/// xml tags in Ignition Gazebo .sdf file define behavior as follows:
+///
+/// \brief <JointName>  The name of the joint to control. Required parameter.
+///
+/// <SpringType> \brief Type of Spring, options are 'linear', 'pneumatic_adiabatic', 'pneumatic_calibrated'  - Currently Unused
+///
+/// <SpringConst> \brief The spring constant.  Required and used when 'SpringType' is 'trivial'.  The default is 1.
+///
+/// <PistonDiam> \brief Piston Diam (inches) Required and used whenever 'SpringType' is not 'trivial'.  The default is 5.  - Currently Unused
+///
+/// <RodDiam> \brief Rod Diamter (inches) Required and used whenever 'SpringType' is not 'trivial'.  The default is 1.5.  - Currently Unused
+///
+/// <PistonEndVolume> \brief Piston End Dead Volume when position is 0 (inches^3). Required and used whenever 'SpringType' is not 'trivial'.  The default is 1430.  - Currently Unused
+///
+/// <RodEndVolume> \brief Rod End Dead Volume when position is 0 (inches^3).  Required and used whenever 'SpringType' is not 'trivial'.  The default is 4700.  - Currently Unused
+///
+/// <PistonEndPressure> \brief Piston End pressure when position is 0 (psia).  Required and used whenever 'SpringType' is not 'trivial'.  The default is 65.  - Currently Unused
+///
+/// <RodEndPressure> \brief Rod End pressure when position is 0 (psia).  Required and used whenever 'SpringType' is not 'trivial'.  The default is 160.  - Currently Unused
+///
+/// <AmbientTemp> \brief Ambient Temperature (degrees C).  Required and used whenever 'SpringType' is not 'trivial'.  The default is 15.  - Currently Unused
+///
+
+
+
+class PolytropicPneumaticSpring
+    : public ignition::gazebo::System,
+      public ignition::gazebo::ISystemConfigure,
+      public ignition::gazebo::ISystemPreUpdate
 {
-// Inline bracket to help doxygen filtering.
-inline namespace IGNITION_GAZEBO_VERSION_NAMESPACE {
-namespace systems
-{
+public:
+  /// \brief Constructor
+  PolytropicPneumaticSpring();
 
-    //enum class SpringType { linear, pneumatic_adiabatic, pneumatic_calibrated};
+  /// \brief Destructor
+  ~PolytropicPneumaticSpring() override = default;
 
-  // Forward declaration
-  struct PolytropicPneumaticSpringPrivate;
+  // Documentation inherited
+  void Configure(const ignition::gazebo::Entity &_entity,
+                 const std::shared_ptr<const sdf::Element> &_sdf,
+                 ignition::gazebo::EntityComponentManager &_ecm,
+                 ignition::gazebo::EventManager &_eventMgr) override;
 
-  /// \brief This can be attached to a model with a reference
-  /// to a single prismatic joint. A force proportional to the
-  /// joint displacement will be applied along the axis of the joint.
-  /// This is an added force that will sum to other forces that may be present.
-  ///
-  /// ## System Parameters
-  ///
-  /// xml tags in Ignition Gazebo .sdf file define behavior as follows:
-  ///
-  /// \brief <JointName>  The name of the joint to control. Required parameter.
-  /// 
-  /// <SpringType> \brief Type of Spring, options are 'linear', 'pneumatic_adiabatic', 'pneumatic_calibrated'  - Currently Unused
-  /// 
-  /// <SpringConst> \brief The spring constant.  Required and used when 'SpringType' is 'trivial'.  The default is 1.
-  /// 
-  /// <PistonDiam> \brief Piston Diam (inches) Required and used whenever 'SpringType' is not 'trivial'.  The default is 5.  - Currently Unused
-  /// 
-  /// <RodDiam> \brief Rod Diamter (inches) Required and used whenever 'SpringType' is not 'trivial'.  The default is 1.5.  - Currently Unused
-  /// 
-  /// <PistonEndVolume> \brief Piston End Dead Volume when position is 0 (inches^3). Required and used whenever 'SpringType' is not 'trivial'.  The default is 1430.  - Currently Unused
-  /// 
-  /// <RodEndVolume> \brief Rod End Dead Volume when position is 0 (inches^3).  Required and used whenever 'SpringType' is not 'trivial'.  The default is 4700.  - Currently Unused
-  /// 
-  /// <PistonEndPressure> \brief Piston End pressure when position is 0 (psia).  Required and used whenever 'SpringType' is not 'trivial'.  The default is 65.  - Currently Unused
-  /// 
-  /// <RodEndPressure> \brief Rod End pressure when position is 0 (psia).  Required and used whenever 'SpringType' is not 'trivial'.  The default is 160.  - Currently Unused
-  ///
-  /// <AmbientTemp> \brief Ambient Temperature (degrees C).  Required and used whenever 'SpringType' is not 'trivial'.  The default is 15.  - Currently Unused
-  /// 
+  // Documentation inherited
+  void PreUpdate(const ignition::gazebo::UpdateInfo &_info,
+                 ignition::gazebo::EntityComponentManager &_ecm) override;
 
+private:
 
+  void computeForce(const double &x, const double &v, const double &n);
 
-  class PolytropicPneumaticSpring
-      : public System,
-        public ISystemConfigure,
-        public ISystemPreUpdate
-  {
-  public:
-    /// \brief Constructor
-    PolytropicPneumaticSpring();
+  ignition::transport::Node node;
+  ignition::transport::Node::Publisher force_pub, pressure_pub, volume_pub, temperature_pub, heat_rate_pub;
 
-    /// \brief Destructor
-    ~PolytropicPneumaticSpring() override = default;
-
-    // Documentation inherited
-    void Configure(const Entity &_entity,
-                   const std::shared_ptr<const sdf::Element> &_sdf,
-                   EntityComponentManager &_ecm,
-                   EventManager &_eventMgr) override;
-
-    // Documentation inherited
-    void PreUpdate(const ignition::gazebo::UpdateInfo &_info,
-                   ignition::gazebo::EntityComponentManager &_ecm) override;
-
-  private:
-
-    void computeForce(const double &x, const double &v, const double &n);
-
-    ignition::transport::Node node;
-    ignition::transport::Node::Publisher force_pub, pressure_pub, volume_pub, temperature_pub, heat_rate_pub;
-    
-    /// \brief Private data pointer
-    std::unique_ptr<PolytropicPneumaticSpringPrivate> dataPtr;
-  };
-  }
-}
-}
-}
+  /// \brief Private data pointer
+  std::unique_ptr<PolytropicPneumaticSpringPrivate> dataPtr;
+};
+} // namespace buoy_gazebo
 
 #endif //IGNITION_GAZEBO_SYSTEMS_POLYTROPIC_PNEUMATICSPRING_HH_

--- a/buoy_gazebo/worlds/electrohydraulicPTO.sdf
+++ b/buoy_gazebo/worlds/electrohydraulicPTO.sdf
@@ -73,7 +73,7 @@
                 </axis>
             </joint>
 
-            <plugin filename="ElectroHydraulicPTO" name="ignition::gazebo::systems::ElectroHydraulicPTO">
+            <plugin filename="ElectroHydraulicPTO" name="buoy_gazebo::ElectroHydraulicPTO">
                 <PrismaticJointName>HydraulicRam</PrismaticJointName>
                 <PistonArea>1.375</PistonArea>
                 <HydMotorDisp>0.30</HydMotorDisp>

--- a/buoy_gazebo/worlds/mbari_wec.sdf
+++ b/buoy_gazebo/worlds/mbari_wec.sdf
@@ -194,7 +194,7 @@
       </joint>
 
 
-      <plugin filename="ElectroHydraulicPTO" name="ignition::gazebo::systems::ElectroHydraulicPTO">
+      <plugin filename="ElectroHydraulicPTO" name="buoy_gazebo::ElectroHydraulicPTO">
         <PrismaticJointName>HydraulicRam</PrismaticJointName>
         <PistonArea>1.375</PistonArea>
         <HydMotorDisp>0.30</HydMotorDisp>
@@ -222,7 +222,7 @@
       </plugin>-->
 
       <!-- Add Upper/Lower Polytropic Spring plugin -->
-      <plugin filename="PolytropicPneumaticSpring" name="ignition::gazebo::systems::PolytropicPneumaticSpring">
+      <plugin filename="PolytropicPneumaticSpring" name="buoy_gazebo::PolytropicPneumaticSpring">
         <JointName>HydraulicRam</JointName>
         <chamber>upper_polytropic</chamber>
         <stroke>2.03</stroke>
@@ -241,7 +241,7 @@
       </plugin>
 
       <!-- <debug_prescribed_velocity>true</debug_prescribed_velocity>-->
-      <plugin filename="PolytropicPneumaticSpring" name="ignition::gazebo::systems::PolytropicPneumaticSpring">
+      <plugin filename="PolytropicPneumaticSpring" name="buoy_gazebo::PolytropicPneumaticSpring">
         <JointName>HydraulicRam</JointName>
         <chamber>lower_polytropic</chamber>
         <stroke>2.03</stroke>

--- a/buoy_gazebo/worlds/pneumatic_spring.sdf
+++ b/buoy_gazebo/worlds/pneumatic_spring.sdf
@@ -118,7 +118,7 @@
             </joint>
 
             <!-- Add Upper/Lower Adiabatic Spring plugin -->
-            <plugin filename="PolytropicPneumaticSpring" name="ignition::gazebo::systems::PolytropicPneumaticSpring">
+            <plugin filename="PolytropicPneumaticSpring" name="buoy_gazebo::PolytropicPneumaticSpring">
                 <JointName>joint_adiabatic</JointName>
                 <chamber>upper_adiabatic</chamber>
                 <n>1.4</n>
@@ -132,7 +132,7 @@
                 <c_p>1.04</c_p>
             </plugin>
 
-            <plugin filename="PolytropicPneumaticSpring" name="ignition::gazebo::systems::PolytropicPneumaticSpring">
+            <plugin filename="PolytropicPneumaticSpring" name="buoy_gazebo::PolytropicPneumaticSpring">
                 <JointName>joint_adiabatic</JointName>
                 <chamber>lower_adiabatic</chamber>
                 <n>1.4</n>
@@ -192,7 +192,7 @@
 
 
             <!-- Add Upper/Lower Polytropic Spring plugin -->
-            <plugin filename="PolytropicPneumaticSpring" name="ignition::gazebo::systems::PolytropicPneumaticSpring">
+            <plugin filename="PolytropicPneumaticSpring" name="buoy_gazebo::PolytropicPneumaticSpring">
                 <JointName>joint_poly</JointName>
                 <chamber>upper_polytropic</chamber>
                 <stroke>2.03</stroke>
@@ -211,7 +211,7 @@
             </plugin>
 
             <!-- <debug_prescribed_velocity>true</debug_prescribed_velocity>-->
-            <plugin filename="PolytropicPneumaticSpring" name="ignition::gazebo::systems::PolytropicPneumaticSpring">
+            <plugin filename="PolytropicPneumaticSpring" name="buoy_gazebo::PolytropicPneumaticSpring">
                 <JointName>joint_poly</JointName>
                 <chamber>lower_polytropic</chamber>
                 <stroke>2.03</stroke>


### PR DESCRIPTION
Adopting some good practices:

* Classes belonging to this project should use the project's namespace. The `ignition::gazebo` namespace is reserved for code that's part of the core simulator and the plugins we officially distribute.
* Avoid `using namespace`s from other projects - this is something that ROS's default linters actually complain about

Using a single `buoy_gazebo` namespace instead of various nested namespaces should also help with appeasing both uncrustify and cpplint at the same time.

The PR should be easier to review if you hide whitespace changes.