### PR TITLE
Use Focal on CI (Ubuntu latest is Jammy now)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
           - gz-version: "fortress"
             ros-distro: "galactic"
     container:
-      image: ubuntu:latest
+      image: ubuntu:20.04
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ on: [push, pull_request]
 jobs:
   tests:
     name: Build and test
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         include:


### PR DESCRIPTION
Ubuntu latest must have been updated recently to point to Jammy, which doesn't have ROS Galactic and makes our CI fail.