### PR TITLE
Fix ElectroHydraulic crash

### DIFF
--- a/buoy_gazebo/src/ElectroHydraulicPTO/ElectroHydraulicPTO.cpp
+++ b/buoy_gazebo/src/ElectroHydraulicPTO/ElectroHydraulicPTO.cpp
@@ -377,9 +377,10 @@ void ElectroHydraulicPTO::PreUpdate(
   double N = this->dataPtr->x[0];
   double deltaP = this->dataPtr->x[1];
   // Shame to have to re-compute this, but small effort...
+  unsigned int seed{1};
   this->dataPtr->TargetWindingCurrent = this->dataPtr->functor.I_Wind(N);
   this->dataPtr->WindingCurrent = this->dataPtr->TargetWindingCurrent + 0.001 *
-    (rand_r(static_cast<unsigned int *>(nullptr)) % 200 - 100);
+    (rand_r(&seed) % 200 - 100);
 
   double eff_e = 0.85;
   double ShaftPower = -1.375 * this->dataPtr->functor.I_Wind.TorqueConstantNMPerAmp *


### PR DESCRIPTION
A little crash was introduced in #3. Try for example:

```
ros2 launch buoy_gazebo mbari_wec.launch.py
```

Then press play, and the simulation crashes.

Originally, the `rand()` function was used, but that resulted in this warning:

```
Consider using rand_r(...) instead of rand(...) for improved thread safety.  [runtime/threadsafe_fn] [2]
```

The proposed fix here is to use a fixed a seed when calling `rand_r`. This should make the simulation more deterministic, which is usually desirable. But if we really want a different value each time the simulation is run, we could seed it with the current time.