### PR TITLE
Adding buoyancy

### DIFF
--- a/buoy_description/models/mbari_wec/model.sdf.em
+++ b/buoy_description/models/mbari_wec/model.sdf.em
@@ -72,11 +72,11 @@ tether_bottom_link_cylinder.mass_matrix(tether_bottom_link_mm)
         </material>
       </visual>
       <collision name="collision">
-        <pose>0 0 2.16 0 0 0 </pose>
+        <pose>0 0 2.26 0 0 0 </pose>
         <geometry>
-          <mesh>
-            <uri>meshes/buoy_float.stl</uri>
-          </mesh>
+          <box>
+            <size>2.65 2.65 4.65</size>
+          </box>
         </geometry>
       </collision>
     </link>
@@ -108,7 +108,6 @@ tether_bottom_link_cylinder.mass_matrix(tether_bottom_link_mm)
         </material>
       </visual>
       <collision name="collision">
-        <pose>0 0 -3.04 0 0 0 </pose>
         <geometry>
           <mesh>
             <uri>meshes/pto_collision.stl</uri>

--- a/buoy_description/models/mbari_wec/model.sdf.em
+++ b/buoy_description/models/mbari_wec/model.sdf.em
@@ -72,10 +72,10 @@ tether_bottom_link_cylinder.mass_matrix(tether_bottom_link_mm)
         </material>
       </visual>
       <collision name="collision">
-        <pose>0 0 2.26 0 0 0 </pose>
+        <pose>0 0 2.46 0 0 0 </pose>
         <geometry>
           <box>
-            <size>2.65 2.65 4.65</size>
+            <size>2.34 2.34 1</size>
           </box>
         </geometry>
       </collision>

--- a/buoy_description/models/mbari_wec/model.sdf.em
+++ b/buoy_description/models/mbari_wec/model.sdf.em
@@ -267,9 +267,9 @@ tether_bottom_link_cylinder.mass_matrix(tether_bottom_link_mm)
       <collision name="HeaveConeCollision">
         <pose>0 0 -1.21 0 0 0 </pose>
         <geometry>
-          <mesh>
-            <uri>meshes/heave_cone.stl</uri>
-          </mesh>
+          <box>
+            <size>0.578 0.578 0.5771</size>
+          </box>
         </geometry>
       </collision>
     </link>

--- a/buoy_description/models/mbari_wec/model.sdf.em
+++ b/buoy_description/models/mbari_wec/model.sdf.em
@@ -71,6 +71,14 @@ tether_bottom_link_cylinder.mass_matrix(tether_bottom_link_mm)
           <specular>1.0 1.0 0.0 1</specular>
         </material>
       </visual>
+      <collision name="collision">
+        <pose>0 0 2.16 0 0 0 </pose>
+        <geometry>
+          <mesh>
+            <uri>meshes/buoy_float.stl</uri>
+          </mesh>
+        </geometry>
+      </collision>
     </link>
 
     <link name="PTO">
@@ -100,6 +108,7 @@ tether_bottom_link_cylinder.mass_matrix(tether_bottom_link_mm)
         </material>
       </visual>
       <collision name="collision">
+        <pose>0 0 -3.04 0 0 0 </pose>
         <geometry>
           <mesh>
             <uri>meshes/pto_collision.stl</uri>
@@ -264,7 +273,7 @@ tether_bottom_link_cylinder.mass_matrix(tether_bottom_link_mm)
           <specular>0.1 0.1 .1 1</specular>
         </material>
       </visual>
-      <collision name="HeaveConeCollision">
+      <collision name="collision">
         <pose>0 0 -1.21 0 0 0 </pose>
         <geometry>
           <box>

--- a/buoy_description/models/mbari_wec/model.sdf.em
+++ b/buoy_description/models/mbari_wec/model.sdf.em
@@ -264,6 +264,14 @@ tether_bottom_link_cylinder.mass_matrix(tether_bottom_link_mm)
           <specular>0.1 0.1 .1 1</specular>
         </material>
       </visual>
+      <collision name="HeaveConeCollision">
+        <pose>0 0 -1.21 0 0 0 </pose>
+        <geometry>
+          <mesh>
+            <uri>meshes/heave_cone.stl</uri>
+          </mesh>
+        </geometry>
+      </collision>
     </link>
 
     <link name="Trefoil">

--- a/buoy_gazebo/worlds/mbari_wec.sdf
+++ b/buoy_gazebo/worlds/mbari_wec.sdf
@@ -8,6 +8,21 @@
     </physics>
 
     <plugin
+      filename="ignition-gazebo-physics-system"
+      name="ignition::gazebo::systems::Physics">
+    </plugin>
+
+    <plugin
+      filename="ignition-gazebo-user-commands-system"
+      name="ignition::gazebo::systems::UserCommands">
+    </plugin>
+
+    <plugin
+      filename="ignition-gazebo-scene-broadcaster-system"
+      name="ignition::gazebo::systems::SceneBroadcaster">
+    </plugin>
+
+    <plugin
       filename="ignition-gazebo-buoyancy-system"
       name="ignition::gazebo::systems::Buoyancy">
       <uniform_fluid_density>1000</uniform_fluid_density>

--- a/buoy_gazebo/worlds/mbari_wec.sdf
+++ b/buoy_gazebo/worlds/mbari_wec.sdf
@@ -25,7 +25,13 @@
     <plugin
       filename="ignition-gazebo-buoyancy-system"
       name="ignition::gazebo::systems::Buoyancy">
-      <uniform_fluid_density>1000</uniform_fluid_density>
+      <graded_buoyancy>
+        <default_density>1025</default_density>
+        <density_change>
+          <above_depth>0</above_depth>
+          <density>1</density>
+        </density_change>
+      </graded_buoyancy>
     </plugin>
 
     <light name="sun" type="directional">
@@ -41,6 +47,25 @@
       </attenuation>
       <direction>-0.5 0.1 -0.9</direction>
     </light>
+
+    <model name="water_plane">
+      <static>true</static>
+      <link name="link">
+        <visual name="water_plane">
+          <geometry>
+            <plane>
+              <size>100 100</size>
+              <normal>0 0 1</normal>
+            </plane>
+          </geometry>
+          <material>
+            <ambient>0 0 1 0.5</ambient>
+            <diffuse>0 0 1 0.5</diffuse>
+            <specular>0 0 1 0.5</specular>
+          </material>
+        </visual>
+      </link>
+    </model>
 
     <model name="MBARI_WEC">
       <pose relative_to="world">0 0 -2 0 0 0</pose>

--- a/buoy_gazebo/worlds/mbari_wec.sdf
+++ b/buoy_gazebo/worlds/mbari_wec.sdf
@@ -7,6 +7,12 @@
       <real_time_factor>1.0</real_time_factor>
     </physics>
 
+    <plugin
+      filename="ignition-gazebo-buoyancy-system"
+      name="ignition::gazebo::systems::Buoyancy">
+      <uniform_fluid_density>1000</uniform_fluid_density>
+    </plugin>
+
     <light name="sun" type="directional">
       <cast_shadows>true</cast_shadows>
       <pose>0 0 10 0 0 0</pose>

--- a/buoy_gazebo/worlds/mbari_wec.sdf
+++ b/buoy_gazebo/worlds/mbari_wec.sdf
@@ -74,26 +74,6 @@
         <uri>model://mbari_wec</uri>
       </include>
 
-      <!-- TODO(chapulina) Remove once buoyancy is in action -->
-      <joint name="WaterPlaneArea" type="prismatic">
-        <parent>world</parent>
-        <child>Buoy</child>
-        <pose>0 0 0 0 0 0</pose>
-        <axis>
-          <limit>
-            <lower>-2.0</lower>
-            <upper>2.0</upper>
-          </limit>
-          <xyz>0.0 0.0 1.0</xyz>
-          <dynamics>
-            <spring_stiffness>55000</spring_stiffness>
-            <spring_reference>0.0</spring_reference>
-            <damping>1000.0</damping>
-            <friction>0.0</friction>
-          </dynamics>
-        </axis>
-      </joint>
-
       <plugin filename="ElectroHydraulicPTO" name="buoy_gazebo::ElectroHydraulicPTO">
         <PrismaticJointName>HydraulicRam</PrismaticJointName>
         <PistonArea>1.375</PistonArea>


### PR DESCRIPTION
Adding Gazebo's [Buoyancy](https://gazebosim.org/api/gazebo/6.6/classignition_1_1gazebo_1_1systems_1_1Buoyancy.html#details) plugin to the world.

PTO and Heave Cone volume should come to `0.3139 m^3` and `0.1928 m^3`, respectively. Assuming buoy volume to be `~5.47 m^3` (using 1m height).
Also, updated center of buoyancy from [#31](https://github.com/osrf/buoy_sim/issues/31). Since collision won't be used for anything else right now, made heave cone and buoy collision geometry to be a cuboid, pto is using mesh.
- Graded buoyancy with water density `1025 km/m^3`
- Added water plane
- Removed WaterPlanarArea joint, buoy seems stable

<img src="https://user-images.githubusercontent.com/24695820/167746890-ea026850-b6a4-40d1-82ba-524c6a662811.png" width="600" height="250"> <img src="https://user-images.githubusercontent.com/24695820/167746391-e5fb310e-3a06-4893-9470-9f5f6829c5ef.png" width="200" height="350">


To run: 
```
ign gazebo mbari_wec.sdf
```