### PR TITLE
Move joint to world out of model

### DIFF
--- a/buoy_description/models/mbari_wec/model.sdf.em
+++ b/buoy_description/models/mbari_wec/model.sdf.em
@@ -294,26 +294,6 @@ tether_bottom_link_cylinder.mass_matrix(tether_bottom_link_mm)
       </visual>
     </link>
 
-    <!-- TODO(chapulina) Remove once buoyancy is in action -->
-    <joint name="WaterPlaneArea" type="prismatic">
-      <parent>world</parent>
-      <child>Buoy</child>
-      <pose>0 0 0 0 0 0</pose>
-      <axis>
-        <limit>
-          <lower>-2.0</lower>
-          <upper>2.0</upper>
-        </limit>
-        <xyz>0.0 0.0 1.0</xyz>
-        <dynamics>
-          <spring_stiffness>55000</spring_stiffness>
-          <spring_reference>0.0</spring_reference>
-          <damping>1000.0</damping>
-          <friction>0.0</friction>
-        </dynamics>
-      </axis>
-    </joint>
-
     <joint name="Universal" type="ball">
       <parent>Buoy</parent>
       <child>PTO</child>

--- a/buoy_gazebo/worlds/mbari_wec.sdf
+++ b/buoy_gazebo/worlds/mbari_wec.sdf
@@ -21,9 +21,32 @@
       <direction>-0.5 0.1 -0.9</direction>
     </light>
 
-    <include>
+    <model name="MBARI_WEC">
       <pose relative_to="world">0 0 -2 0 0 0</pose>
-      <uri>model://mbari_wec</uri>
+
+      <include merge="true">
+        <uri>model://mbari_wec</uri>
+      </include>
+
+      <!-- TODO(chapulina) Remove once buoyancy is in action -->
+      <joint name="WaterPlaneArea" type="prismatic">
+        <parent>world</parent>
+        <child>Buoy</child>
+        <pose>0 0 0 0 0 0</pose>
+        <axis>
+          <limit>
+            <lower>-2.0</lower>
+            <upper>2.0</upper>
+          </limit>
+          <xyz>0.0 0.0 1.0</xyz>
+          <dynamics>
+            <spring_stiffness>55000</spring_stiffness>
+            <spring_reference>0.0</spring_reference>
+            <damping>1000.0</damping>
+            <friction>0.0</friction>
+          </dynamics>
+        </axis>
+      </joint>
 
       <plugin filename="ElectroHydraulicPTO" name="buoy_gazebo::ElectroHydraulicPTO">
         <PrismaticJointName>HydraulicRam</PrismaticJointName>
@@ -70,6 +93,6 @@
         <P2>1212140</P2>
       </plugin>
       <!-- <debug_prescribed_velocity>true</debug_prescribed_velocity>-->
-    </include>
+    </model>
   </world>
 </sdf>


### PR DESCRIPTION
The `WaterPlaneArea` joint is just a temporary trick to prevent the model from sinking. We'll remove it eventually, but until then, it would be convenient to move it out of the model, so that the model can be reused in other worlds without that trick.

I actually did this as part of #26 so that the playground world can have a different joint to the world. Moving it to a separate PR for quicker review, and to remove future conflicts when the joint is removed.

This change shouldn't change the behaviour of the `mbari_wec` world.