### PR TITLE
Move world plugins to a config file

### DIFF
--- a/buoy_gazebo/CMakeLists.txt
+++ b/buoy_gazebo/CMakeLists.txt
@@ -68,6 +68,7 @@ add_subdirectory(src)
 install(DIRECTORY
   worlds
   launch
+  gazebo
   DESTINATION share/${PROJECT_NAME}/
 )
 

--- a/buoy_gazebo/gazebo/server.config
+++ b/buoy_gazebo/gazebo/server.config
@@ -1,0 +1,32 @@
+<?xml version="1.0" ?>
+<server_config>
+  <plugins>
+    <plugin entity_name="*"
+            entity_type="world"
+            filename="ignition-gazebo-physics-system"
+            name="ignition::gazebo::systems::Physics">
+    </plugin>
+    <plugin entity_name="*"
+            entity_type="world"
+            filename="ignition-gazebo-user-commands-system"
+            name="ignition::gazebo::systems::UserCommands">
+    </plugin>
+    <plugin entity_name="*"
+            entity_type="world"
+            filename="ignition-gazebo-scene-broadcaster-system"
+            name="ignition::gazebo::systems::SceneBroadcaster">
+    </plugin>
+    <plugin entity_name="*"
+            entity_type="world"
+      filename="ignition-gazebo-buoyancy-system"
+      name="ignition::gazebo::systems::Buoyancy">
+      <graded_buoyancy>
+        <default_density>1025</default_density>
+        <density_change>
+          <above_depth>0</above_depth>
+          <density>1</density>
+        </density_change>
+      </graded_buoyancy>
+    </plugin>
+  </plugins>
+</server_config>

--- a/buoy_gazebo/hooks/buoy_gazebo.dsv.in
+++ b/buoy_gazebo/hooks/buoy_gazebo.dsv.in
@@ -1,3 +1,4 @@
 prepend-non-duplicate;IGN_GAZEBO_RESOURCE_PATH;share/@PROJECT_NAME@/worlds
 prepend-non-duplicate;IGN_GAZEBO_SYSTEM_PLUGIN_PATH;@CMAKE_INSTALL_PREFIX@/lib
+prepend-non-duplicate;IGN_GAZEBO_SERVER_CONFIG_PATH;share/@PROJECT_NAME@/gazebo/server.config
 set-if-unset;MESA_GL_VERSION_OVERRIDE;3.3

--- a/buoy_gazebo/worlds/mbari_wec.sdf
+++ b/buoy_gazebo/worlds/mbari_wec.sdf
@@ -7,32 +7,7 @@
       <real_time_factor>1.0</real_time_factor>
     </physics>
 
-    <plugin
-      filename="ignition-gazebo-physics-system"
-      name="ignition::gazebo::systems::Physics">
-    </plugin>
-
-    <plugin
-      filename="ignition-gazebo-user-commands-system"
-      name="ignition::gazebo::systems::UserCommands">
-    </plugin>
-
-    <plugin
-      filename="ignition-gazebo-scene-broadcaster-system"
-      name="ignition::gazebo::systems::SceneBroadcaster">
-    </plugin>
-
-    <plugin
-      filename="ignition-gazebo-buoyancy-system"
-      name="ignition::gazebo::systems::Buoyancy">
-      <graded_buoyancy>
-        <default_density>1025</default_density>
-        <density_change>
-          <above_depth>0</above_depth>
-          <density>1</density>
-        </density_change>
-      </graded_buoyancy>
-    </plugin>
+    <!-- rely on world plugins from server.config -->
 
     <light name="sun" type="directional">
       <cast_shadows>true</cast_shadows>


### PR DESCRIPTION
On #12 all world plugins were removed from the world files so we could load the defaults instead. But then on #33 we needed a non-default plugin, which meant we had to add all others.

This PR moves those plugins to a `server.config` file and points to that file using the `IGN_GAZEBO_SERVER_CONFIG_PATH`, so that becomes the new default set of plugins. This way, buoyancy will be enabled by default for all worlds.

It's still possible to override this config file by explicitly listing plugins inside each world file as needed.

There's more info about server configs on [this tutorial](https://gazebosim.org/api/gazebo/6.9/server_config.html).

## Test it

Run

`ign gazebo mbari_wec.sdf -r`

The simulation should start and the buoy bounces up and down due to buoyancy.