### PR TITLE
Setup profiler

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,3 +2,16 @@ This repository contains packages used for Gazebo simulation of marine buoys.
 
 Start from [Buoy entrypoint](https://github.com/osrf/buoy_entrypoint).
 
+## Development
+
+### Profiler
+
+By default, the profiler isn't enabled. To enable it at compilation time,
+pass the `-DENABLE_PROFILER=1` CMake argument. For example, to compile tests
+and enable the profiler with `colcon`:
+
+```
+colcon build --cmake-args ' -DBUILD_TESTING=false' ' -DENABLE_PROFILER=1'
+```
+
+See more on [this tutorial](https://ignitionrobotics.org/api/common/4.4/profiler.html).

--- a/buoy_gazebo/CMakeLists.txt
+++ b/buoy_gazebo/CMakeLists.txt
@@ -1,6 +1,15 @@
 cmake_minimum_required(VERSION 3.5)
 project(buoy_gazebo)
 
+# Option to enable profiler
+option(ENABLE_PROFILER "Enable Ignition Profiler" FALSE)
+
+if(ENABLE_PROFILER)
+  add_definitions("-DIGN_PROFILER_ENABLE=1")
+else()
+  add_definitions("-DIGN_PROFILER_ENABLE=0")
+endif()
+
 find_package(ament_cmake REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(buoy_msgs REQUIRED)
@@ -8,6 +17,8 @@ find_package(buoy_msgs REQUIRED)
 find_package(ignition-cmake2 REQUIRED)
 find_package(ignition-plugin1 REQUIRED COMPONENTS register)
 set(IGN_PLUGIN_VER ${ignition-plugin1_VERSION_MAJOR})
+find_package(ignition-common4 REQUIRED COMPONENTS profiler)
+set(IGN_COMMON_VER ${ignition-common4_VERSION_MAJOR})
 find_package(ignition-gazebo6 REQUIRED)
 set(IGN_GAZEBO_VER ${ignition-gazebo6_VERSION_MAJOR})
 
@@ -52,6 +63,7 @@ function(gz_add_plugin plugin_name)
     PUBLIC
       ignition-gazebo${IGN_GAZEBO_VER}::ignition-gazebo${IGN_GAZEBO_VER}
       ignition-plugin${IGN_PLUGIN_VER}::ignition-plugin${IGN_PLUGIN_VER}
+      ignition-common${IGN_COMMON_VER}::profiler
       ${gz_add_plugin_PUBLIC_LINK_LIBS}
     PRIVATE
       ${gz_add_plugin_PRIVATE_LINK_LIBS}

--- a/buoy_gazebo/src/ElectroHydraulicPTO/ElectroHydraulicPTO.cpp
+++ b/buoy_gazebo/src/ElectroHydraulicPTO/ElectroHydraulicPTO.cpp
@@ -306,15 +306,13 @@ void ElectroHydraulicPTO::PreUpdate(
   const int n = 2;
   int info;
 
-  IGN_PROFILE("ElectroHydraulicPTO::Update");
+  IGN_PROFILE("#ElectroHydraulicPTO::PreUpdate");
   // Nothing left to do if paused.
   if (_info.paused) {
     return;
   }
 
   auto SimTime = std::chrono::duration<double>(_info.simTime).count();
-
-  IGN_PROFILE("#ElectroHydraulicPTO::PreUpdate");
 
   // If the joints haven't been identified yet, the plugin is disabled
   if (this->dataPtr->PrismaticJointEntity == ignition::gazebo::kNullEntity) {


### PR DESCRIPTION
[Ignition Common's profiler](https://ignitionrobotics.org/api/common/4.4/profiler.html) is very handy to debug performance.

This PR just sets up the profiler and makes use of the existing profiling points.

See the snippet added to the README for how to enable and use it. In order to get profiling points coming from the Gazebo libraries themselves, they need to be compiled from source with `-DENABLE_PROFILER=1`.

Here's some example output. I was surprised to see that the `PolytropicPneumaticSpring` is taking up almost as much time as the physics' forward step.

![buoy_profiler](https://user-images.githubusercontent.com/5751272/171298386-896040e2-ffd2-4ed0-9968-79b3288ce166.png)

