### PR TITLE
Add buoy_tests package and a simple test

### DIFF
--- a/.github/workflows/build-and-test.sh
+++ b/.github/workflows/build-and-test.sh
@@ -32,7 +32,7 @@ rosdep install --from-paths ./ -i -y -r --rosdistro $ROS_DISTRO
 # Build everything up to buoy_gazebo
 source /opt/ros/$ROS_DISTRO/setup.bash
 cd $COLCON_WS
-colcon build --packages-up-to buoy_gazebo --event-handlers console_direct+
+colcon build --packages-up-to buoy_tests --event-handlers console_direct+
 
 # Test all buoy packages
 colcon test --packages-select-regex=buoy --event-handlers console_direct+

--- a/buoy_tests/CMakeLists.txt
+++ b/buoy_tests/CMakeLists.txt
@@ -1,0 +1,40 @@
+cmake_minimum_required(VERSION 3.5)
+project(buoy_tests)
+
+if(NOT BUILD_TESTING)
+  return()
+endif()
+
+find_package(ament_cmake REQUIRED)
+
+find_package(ignition-gazebo6 REQUIRED)
+set(GZ_SIM_VER ${ignition-gazebo6_VERSION_MAJOR})
+
+# Linters
+find_package(ament_lint_auto REQUIRED)
+ament_lint_auto_find_test_dependencies()
+
+# GTest
+find_package(ament_cmake_gtest REQUIRED)
+find_package(launch_testing_ament_cmake REQUIRED)
+ament_find_gtest()
+
+# Helper function to generate tests
+function(buoy_add_test TEST_NAME)
+
+  ament_add_gtest(${TEST_NAME} tests/${TEST_NAME}.cpp)
+  target_link_libraries(${TEST_NAME}
+    ignition-gazebo${GZ_SIM_VER}::ignition-gazebo${GZ_SIM_VER}
+  )
+  include_directories(${CMAKE_CURRENT_BINARY_DIR})
+  install(
+    TARGETS ${TEST_NAME}
+    DESTINATION lib/${PROJECT_NAME}
+  )
+
+endfunction()
+
+# Add tests
+buoy_add_test(no_inputs)
+
+ament_package()

--- a/buoy_tests/CMakeLists.txt
+++ b/buoy_tests/CMakeLists.txt
@@ -16,7 +16,6 @@ ament_lint_auto_find_test_dependencies()
 
 # GTest
 find_package(ament_cmake_gtest REQUIRED)
-find_package(launch_testing_ament_cmake REQUIRED)
 ament_find_gtest()
 
 # Helper function to generate tests

--- a/buoy_tests/package.xml
+++ b/buoy_tests/package.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>buoy_tests</name>
+  <version>0.0.0</version>
+  <description>Tests for buoy simulation.</description>
+  <maintainer email="louise@openrobotics.org">Louise Poubel</maintainer>
+  <license>Apache 2.0</license>
+  <author>Louise Poubel</author>
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+
+  <test_depend>buoy_gazebo</test_depend>
+  <test_depend>ament_cmake_gtest</test_depend>
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>ament_lint_common</test_depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>

--- a/buoy_tests/tests/no_inputs.cpp
+++ b/buoy_tests/tests/no_inputs.cpp
@@ -1,0 +1,86 @@
+// Copyright 2022 Open Source Robotics Foundation, Inc. and Monterey Bay Aquarium Research Institute
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+
+#include <ignition/common/Console.hh>
+#include <ignition/gazebo/World.hh>
+#include <ignition/gazebo/Server.hh>
+#include <ignition/gazebo/Util.hh>
+#include <ignition/gazebo/TestFixture.hh>
+#include <ignition/transport/Node.hh>
+
+#include <memory>
+
+//////////////////////////////////////////////////
+TEST(BuoyTests, NoInputs)
+{
+  // Skip debug messages to run faster
+  ignition::common::Console::SetVerbosity(3);
+
+  // Setup fixture
+  ignition::gazebo::ServerConfig config;
+  config.SetSdfFile("mbari_wec.sdf");
+  config.SetUpdateRate(0.0);
+
+  ignition::gazebo::TestFixture fixture(config);
+
+  int iterations{0};
+  ignition::gazebo::Entity buoyEntity{ignition::gazebo::kNullEntity};
+
+  fixture.
+  OnConfigure(
+    [&](const ignition::gazebo::Entity & _worldEntity,
+    const std::shared_ptr<const sdf::Element> &,
+    ignition::gazebo::EntityComponentManager & _ecm,
+    ignition::gazebo::EventManager &)
+    {
+      auto world = ignition::gazebo::World(_worldEntity);
+
+      buoyEntity = world.ModelByName(_ecm, "MBARI_WEC");
+      EXPECT_NE(ignition::gazebo::kNullEntity, buoyEntity);
+    }).
+  OnPostUpdate(
+    [&](
+      const ignition::gazebo::UpdateInfo &,
+      const ignition::gazebo::EntityComponentManager & _ecm)
+    {
+      iterations++;
+
+      auto pose = ignition::gazebo::worldPose(buoyEntity, _ecm);
+
+      // Expect buoy to stay more or less in the same place horizontally.
+      EXPECT_LT(-0.001, pose.Pos().X());
+      EXPECT_GT(0.001, pose.Pos().X());
+
+      EXPECT_LT(-0.001, pose.Pos().Y());
+      EXPECT_GT(0.001, pose.Pos().Y());
+
+      // Buoy starts at Z == -2.0
+      // It's slightly out of the water, so it falls ~1m
+      EXPECT_LT(-3.020, pose.Pos().Z());
+
+      // And it bounces back up beyond its starting point
+      EXPECT_GT(-1.89, pose.Pos().Z());
+    }).
+  Finalize();
+
+  // Run simulation server
+  int targetIterations{5000};
+  fixture.Server()->Run(true /*blocking*/, targetIterations, false /*paused*/);
+
+  // Sanity check that the test ran
+  EXPECT_EQ(targetIterations, iterations);
+  EXPECT_NE(ignition::gazebo::kNullEntity, buoyEntity);
+}


### PR DESCRIPTION
* Closes #37 

Created a new package to hold simulation-enabled tests.

I added a very simple test that checks that the buoy stays within bounds if no inputs are given. I'm only checking the position but we could extend it to check velocities, accelerations, etc.

The current test doesn't use ROS 2 at all. For ROS 2 enabled tests we'll likely use `launch_testing`. 

## Try it out

1. Compile with `colcon build --cmake-args -DBUILD_TESTING=true`
2. Run the test with one of these:
    1. `colcon test --packages-select buoy_tests` - this will also run linters and in the future other tests
    2. `./install/lib/buoy_tests/no_inputs` - this runs just the new test
