### PR TITLE
add PowerController ROS2 node

### DIFF
--- a/buoy_gazebo/CMakeLists.txt
+++ b/buoy_gazebo/CMakeLists.txt
@@ -1,6 +1,10 @@
 cmake_minimum_required(VERSION 3.5)
 project(buoy_gazebo)
 
+# if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+#   add_compile_options(-Wall -Wextra -Wpedantic)
+# endif()
+
 # Option to enable profiler
 option(ENABLE_PROFILER "Enable Ignition Profiler" FALSE)
 
@@ -30,6 +34,7 @@ set(GZ_SIM_VER ${ignition-gazebo6_VERSION_MAJOR})
 #              [PUBLIC_LINK_LIBS <libraries...>]
 #              [PRIVATE_LINK_LIBS <libraries...>])
 #              [INCLUDE_DIRS <paths_to_directories...>
+#              [ROS]
 #
 # Add a system plugin
 #
@@ -44,6 +49,8 @@ set(GZ_SIM_VER ${ignition-gazebo6_VERSION_MAJOR})
 #
 # [INCLUDE_DIRS]: Specify a list of path to directories to be included,
 #
+# [ROS]: Signal that this plugin is ROS-enabled
+
 function(gz_add_plugin plugin_name)
   set(options ROS)
   set(oneValueArgs)
@@ -73,6 +80,7 @@ function(gz_add_plugin plugin_name)
   endif()
   target_include_directories(${plugin_name}
       PUBLIC ${gz_add_plugin_INCLUDE_DIRS})
+  # target_compile_features(${plugin_name} PUBLIC c_std_99 cxx_std_17)  # Require C99 and C++17
   install(
     TARGETS ${plugin_name}
     DESTINATION lib)

--- a/buoy_gazebo/src/ElectroHydraulicPTO/CMakeLists.txt
+++ b/buoy_gazebo/src/ElectroHydraulicPTO/CMakeLists.txt
@@ -3,4 +3,5 @@ gz_add_plugin(ElectroHydraulicPTO
     ElectroHydraulicPTO.cpp
   INCLUDE_DIRS
     include/
+    ..
 )

--- a/buoy_gazebo/src/ElectroHydraulicPTO/ElectroHydraulicPTO.cpp
+++ b/buoy_gazebo/src/ElectroHydraulicPTO/ElectroHydraulicPTO.cpp
@@ -496,27 +496,28 @@ void ElectroHydraulicPTO::PreUpdate(
 
 
   // Assign Values
-  ElectroHydraulicState PTO_Values;
-  PTO_Values.xdot = xdot / 0.0254;
-  PTO_Values.N = N;
-  PTO_Values.deltaP = deltaP;
-  PTO_Values.VBus = VBus;
-  PTO_Values.TargetWindingCurrent = this->dataPtr->TargetWindingCurrent;
-  PTO_Values.WindingCurrent = this->dataPtr->WindingCurrent;
-  PTO_Values.I_Batt = I_Batt;
-  PTO_Values.I_Load = I_Load;
-  PTO_Values.ScaleFactor = this->dataPtr->functor.I_Wind.ScaleFactor;
-  PTO_Values.RetractFactor = this->dataPtr->functor.I_Wind.RetractFactor;
+  ElectroHydraulicState pto_state;
+  pto_state.rpm = N;
+  pto_state.voltage = VBus;
+  pto_state.bcurrent = I_Batt;
+  pto_state.wcurrent = this->dataPtr->WindingCurrent;
+  pto_state.diff_press = deltaP;
+  pto_state.loaddc = I_Load;
+  pto_state.scale = this->dataPtr->functor.I_Wind.ScaleFactor;
+  pto_state.retract = this->dataPtr->functor.I_Wind.RetractFactor;
+  pto_state.target_a = this->dataPtr->TargetWindingCurrent;
 
 
   // Create new component for this entitiy in ECM (if it doesn't already exist)
-  auto PTO_State_comp = _ecm.Component<buoy_gazebo::PTO_State>(this->dataPtr->PrismaticJointEntity);
-  if (PTO_State_comp == nullptr) {
+  auto pto_state_comp =
+    _ecm.Component<buoy_gazebo::components::ElectroHydraulicState>(
+      this->dataPtr->PrismaticJointEntity);
+  if (pto_state_comp == nullptr) {
     _ecm.CreateComponent(
       this->dataPtr->PrismaticJointEntity,
-      buoy_gazebo::PTO_State({PTO_Values}));
+      buoy_gazebo::components::ElectroHydraulicState({pto_state}));
   } else {
-    PTO_State_comp->Data() = PTO_Values;
+    pto_state_comp->Data() = pto_state;
   }
 
 
@@ -536,35 +537,6 @@ void ElectroHydraulicPTO::PreUpdate(
     }
   }
 }
-
-//////////////////////////////////////////////////
-void ElectroHydraulicPTO::Update(
-  const ignition::gazebo::UpdateInfo & _info,
-  ignition::gazebo::EntityComponentManager & _ecm)
-{
-  IGN_PROFILE("#ElectroHydraulicPTO::Update");
-  // Nothing left to do if paused.
-  if (_info.paused) {
-    return;
-  }
-
-  // auto SimTime = std::chrono::duration < double > (_info.simTime).count();
-}
-
-//////////////////////////////////////////////////
-void ElectroHydraulicPTO::PostUpdate(
-  const ignition::gazebo::UpdateInfo & _info,
-  const ignition::gazebo::EntityComponentManager & _ecm)
-{
-  IGN_PROFILE("#ElectroHydraulicPTO::PostUpdate");
-  // Nothing left to do if paused.
-  if (_info.paused) {
-    return;
-  }
-
-  // auto SimTime = std::chrono::duration < double > (_info.simTime).count();
-}
-
 
 //////////////////////////////////////////////////
 void ElectroHydraulicPTOPrivate::OnUserCmdCurr(const ignition::msgs::Double & _msg)
@@ -595,6 +567,4 @@ IGNITION_ADD_PLUGIN(
   buoy_gazebo::ElectroHydraulicPTO,
   ignition::gazebo::System,
   buoy_gazebo::ElectroHydraulicPTO::ISystemConfigure,
-  buoy_gazebo::ElectroHydraulicPTO::ISystemPreUpdate,
-  buoy_gazebo::ElectroHydraulicPTO::ISystemUpdate,
-  buoy_gazebo::ElectroHydraulicPTO::ISystemPostUpdate);
+  buoy_gazebo::ElectroHydraulicPTO::ISystemPreUpdate);

--- a/buoy_gazebo/src/ElectroHydraulicPTO/ElectroHydraulicPTO.cpp
+++ b/buoy_gazebo/src/ElectroHydraulicPTO/ElectroHydraulicPTO.cpp
@@ -444,6 +444,7 @@ void ElectroHydraulicPTO::PreUpdate(
   pto_state.bcurrent = I_Batt;
   pto_state.wcurrent = this->dataPtr->WindingCurrent;
   pto_state.diff_press = deltaP;
+  pto_state.bias_current = this->dataPtr->functor.I_Wind.BiasCurrent;
   pto_state.loaddc = I_Load;
   pto_state.scale = this->dataPtr->functor.I_Wind.ScaleFactor;
   pto_state.retract = this->dataPtr->functor.I_Wind.RetractFactor;

--- a/buoy_gazebo/src/ElectroHydraulicPTO/ElectroHydraulicPTO.hpp
+++ b/buoy_gazebo/src/ElectroHydraulicPTO/ElectroHydraulicPTO.hpp
@@ -23,8 +23,6 @@
 
 namespace buoy_gazebo
 {
-// enum class SpringType { linear, pneumatic_adiabatic, pneumatic_calibrated};
-
 // Forward declaration
 class ElectroHydraulicPTOPrivate;
 
@@ -51,9 +49,7 @@ class ElectroHydraulicPTOPrivate;
 ///     <Displacement>  Displacement per revolution of rotary pump/motor.
 class ElectroHydraulicPTO : public ignition::gazebo::System,
   public ignition::gazebo::ISystemConfigure,
-  public ignition::gazebo::ISystemPreUpdate,
-  public ignition::gazebo::ISystemUpdate,
-  public ignition::gazebo::ISystemPostUpdate
+  public ignition::gazebo::ISystemPreUpdate
 {
 public:
   /// \brief Constructor
@@ -73,16 +69,6 @@ public:
   void PreUpdate(
     const ignition::gazebo::UpdateInfo & _info,
     ignition::gazebo::EntityComponentManager & _ecm) override;
-
-  // Documentation inherited
-  void Update(
-    const ignition::gazebo::UpdateInfo & _info,
-    ignition::gazebo::EntityComponentManager & _ecm) override;
-
-  // Documentation inherited
-  void PostUpdate(
-    const ignition::gazebo::UpdateInfo & _info,
-    const ignition::gazebo::EntityComponentManager & _ecm) override;
 
 private:
   ignition::transport::Node node;

--- a/buoy_gazebo/src/ElectroHydraulicPTO/ElectroHydraulicState.hpp
+++ b/buoy_gazebo/src/ElectroHydraulicPTO/ElectroHydraulicState.hpp
@@ -24,33 +24,6 @@
 
 namespace buoy_gazebo
 {
-struct PowerControllerStatusBits {
-  uint8_t Mode : 2;  // controller mode. specified by defines in config.h
-                     // (GENERATOR_MODE, TORQUE_MODE)
-  uint8_t TorqueCmdLimited : 1;  // defines what is limited the Torque Command
-                                 // (0 = Not limited, 1 = Rate, 2 = Min, 3 = Max).
-  uint8_t BattSwitchRequest : 1;  // Indicates state of battery switch that the user desires.
-                                  // (0 = off, 1 = on)
-  uint8_t BattSwitchSetting : 1;  // Indicates instantaneous setting of Battery Switch
-  uint8_t SlowSwitchSetting : 1;  // Indicates instantaneous setting of Bettery Slow Switch
-  uint8_t EXT_Voltage_Detect : 1;  // Indicates if >170V is available on outside connector
-  uint8_t GainScheduleMode : 1;  // 0 = off. 1 = on.
-  uint8_t OverCurrentShutdown : 1;  // 1 indicates drive is in overcurrent shutdown.
-  uint8_t OverVoltageShutdown : 1;  // 1 indicates drive is in overvoltage shutdown.
-  uint8_t SpringRangeValid : 1;  // 1 indicates the current SC_Range value is valid
-                                 // (received within approximately SC_RANGE_VALID_TIMEOUT
-                                 // milliseconds)
-  uint8_t PermissiveMode : 1;  // 1 indicates user has selected "permissive mode" which allows
-                               // WindingCurrent commands to be set even if SpringController
-                               // Range packets aren't arriving
-};
-
-typedef union
-{
-  uint16_t status;
-  PowerControllerStatusBits bits;
-} PowerControllerStatus;
-
 /// \brief State data for power commands and feedback from sensors for PCRecord message in ROS2
 struct ElectroHydraulicState
 {
@@ -68,7 +41,7 @@ struct ElectroHydraulicState
   float retract{0.0F};
   float target_v{0.0F};  // TODO(anyone) not set
   float target_a{0.0F};
-  PowerControllerStatus status{0};  // TODO(anyone) not set
+  int16_t status{0};  // TODO(anyone) not set
   float charge_curr_limit{0.0F};  // TODO(anyone) not set
 
   buoy_utils::CommandTriState<> torque_command;

--- a/buoy_gazebo/src/ElectroHydraulicPTO/ElectroHydraulicState.hpp
+++ b/buoy_gazebo/src/ElectroHydraulicPTO/ElectroHydraulicState.hpp
@@ -44,9 +44,9 @@ struct ElectroHydraulicState
   int16_t status{0};  // TODO(anyone) not set
   float charge_curr_limit{0.0};  // TODO(anyone) not set
 
-  buoy_utils::CommandTriState torque_command;
-  buoy_utils::CommandTriState scale_command;
-  buoy_utils::CommandTriState retract_command;
+  buoy_utils::CommandTriState<> torque_command;
+  buoy_utils::CommandTriState<> scale_command;
+  buoy_utils::CommandTriState<> retract_command;
 };
 
 namespace components

--- a/buoy_gazebo/src/ElectroHydraulicPTO/ElectroHydraulicState.hpp
+++ b/buoy_gazebo/src/ElectroHydraulicPTO/ElectroHydraulicState.hpp
@@ -24,6 +24,33 @@
 
 namespace buoy_gazebo
 {
+struct PowerControllerStatusBits {
+  uint8_t Mode : 2;  // controller mode. specified by defines in config.h
+                     // (GENERATOR_MODE, TORQUE_MODE)
+  uint8_t TorqueCmdLimited : 1;  // defines what is limited the Torque Command
+                                 // (0 = Not limited, 1 = Rate, 2 = Min, 3 = Max).
+  uint8_t BattSwitchRequest : 1;  // Indicates state of battery switch that the user desires.
+                                  // (0 = off, 1 = on)
+  uint8_t BattSwitchSetting : 1;  // Indicates instantaneous setting of Battery Switch
+  uint8_t SlowSwitchSetting : 1;  // Indicates instantaneous setting of Bettery Slow Switch
+  uint8_t EXT_Voltage_Detect : 1;  // Indicates if >170V is available on outside connector
+  uint8_t GainScheduleMode : 1;  // 0 = off. 1 = on.
+  uint8_t OverCurrentShutdown : 1;  // 1 indicates drive is in overcurrent shutdown.
+  uint8_t OverVoltageShutdown : 1;  // 1 indicates drive is in overvoltage shutdown.
+  uint8_t SpringRangeValid : 1;  // 1 indicates the current SC_Range value is valid
+                                 // (received within approximately SC_RANGE_VALID_TIMEOUT
+                                 // milliseconds)
+  uint8_t PermissiveMode : 1;  // 1 indicates user has selected "permissive mode" which allows
+                               // WindingCurrent commands to be set even if SpringController
+                               // Range packets aren't arriving
+};
+
+typedef union
+{
+  uint16_t status;
+  PowerControllerStatusBits bits;
+} PowerControllerStatus;
+
 /// \brief State data for power commands and feedback from sensors for PCRecord message in ROS2
 struct ElectroHydraulicState
 {
@@ -41,7 +68,7 @@ struct ElectroHydraulicState
   float retract{0.0F};
   float target_v{0.0F};  // TODO(anyone) not set
   float target_a{0.0F};
-  int16_t status{0};  // TODO(anyone) not set
+  PowerControllerStatus status{0};  // TODO(anyone) not set
   float charge_curr_limit{0.0F};  // TODO(anyone) not set
 
   buoy_utils::CommandTriState<> torque_command;

--- a/buoy_gazebo/src/ElectroHydraulicPTO/ElectroHydraulicState.hpp
+++ b/buoy_gazebo/src/ElectroHydraulicPTO/ElectroHydraulicState.hpp
@@ -35,7 +35,7 @@ struct ElectroHydraulicState
   float wcurrent{0.0F};
   float torque{0.0F};  // TODO(anyone) not set
   float diff_press{0.0F};
-  float bias_current{0.0F};  // TODO(anyone) not set
+  float bias_current{0.0F};
   float loaddc{0.0F};
   float scale{0.0F};
   float retract{0.0F};

--- a/buoy_gazebo/src/ElectroHydraulicPTO/ElectroHydraulicState.hpp
+++ b/buoy_gazebo/src/ElectroHydraulicPTO/ElectroHydraulicState.hpp
@@ -27,26 +27,48 @@ namespace buoy_gazebo
 /// \brief State data for power commands and feedback from sensors for PCRecord message in ROS2
 struct ElectroHydraulicState
 {
-  float rpm{0.0};
-  float sd_rpm{0.0};  // TODO(anyone) not set
-  float voltage{0.0};
-  float draw_curr_limit{0.0};  // TODO(anyone) not set
-  float bcurrent{0.0};
-  float wcurrent{0.0};
-  float torque{0.0};  // TODO(anyone) not set
-  float diff_press{0.0};
-  float bias_current{0.0};  // TODO(anyone) not set
-  float loaddc{0.0};
-  float scale{0.0};
-  float retract{0.0};
-  float target_v{0.0};  // TODO(anyone) not set
-  float target_a{0.0};
+  float rpm{0.0F};
+  float sd_rpm{0.0F};  // TODO(anyone) not set
+  float voltage{0.0F};
+  float draw_curr_limit{0.0F};  // TODO(anyone) not set
+  float bcurrent{0.0F};
+  float wcurrent{0.0F};
+  float torque{0.0F};  // TODO(anyone) not set
+  float diff_press{0.0F};
+  float bias_current{0.0F};  // TODO(anyone) not set
+  float loaddc{0.0F};
+  float scale{0.0F};
+  float retract{0.0F};
+  float target_v{0.0F};  // TODO(anyone) not set
+  float target_a{0.0F};
   int16_t status{0};  // TODO(anyone) not set
-  float charge_curr_limit{0.0};  // TODO(anyone) not set
+  float charge_curr_limit{0.0F};  // TODO(anyone) not set
 
   buoy_utils::CommandTriState<> torque_command;
   buoy_utils::CommandTriState<> scale_command;
   buoy_utils::CommandTriState<> retract_command;
+  buoy_utils::CommandTriState<> bias_current_command;
+
+  bool operator==(const ElectroHydraulicState & that) const
+  {
+    bool equal = fabs(this->rpm - that.rpm) < 1e-7F;
+    equal &= fabs(this->sd_rpm - that.sd_rpm) < 1e-7F;
+    equal &= fabs(this->voltage - that.voltage) < 1e-7F;
+    equal &= fabs(this->draw_curr_limit - that.draw_curr_limit) < 1e-7F;
+    equal &= fabs(this->bcurrent - that.bcurrent) < 1e-7F;
+    equal &= fabs(this->wcurrent - that.wcurrent) < 1e-7F;
+    equal &= fabs(this->torque - that.torque) < 1e-7F;
+    equal &= fabs(this->diff_press - that.diff_press) < 1e-7F;
+    equal &= fabs(this->bias_current - that.bias_current) < 1e-7F;
+    equal &= fabs(this->loaddc - that.loaddc) < 1e-7F;
+    equal &= fabs(this->scale - that.scale) < 1e-7F;
+    equal &= fabs(this->retract - that.retract) < 1e-7F;
+    equal &= fabs(this->target_v - that.target_v) < 1e-7F;
+    equal &= fabs(this->target_a - that.target_a) < 1e-7F;
+    equal &= this->status == that.status;
+    equal &= fabs(this->charge_curr_limit - that.charge_curr_limit) < 1e-7F;
+    return equal;
+  }
 };
 
 namespace components

--- a/buoy_gazebo/src/ElectroHydraulicPTO/ElectroHydraulicState.hpp
+++ b/buoy_gazebo/src/ElectroHydraulicPTO/ElectroHydraulicState.hpp
@@ -19,33 +19,48 @@
 #include <ignition/gazebo/components/Component.hh>
 #include <ignition/gazebo/config.hh>
 
+#include <buoy_utils/CommandTriState.hpp>
+
+
 namespace buoy_gazebo
 {
-
+/// \brief State data for power commands and feedback from sensors for PCRecord message in ROS2
 struct ElectroHydraulicState
 {
-  double xdot{0.0};
-  double N{0.0};
-  double deltaP{0.0};
-  double VBus{0.0};
-  double TargetWindingCurrent{0.0};
-  double WindingCurrent{0.0};
-  double I_Batt{0.0};
-  double I_Load{0.0};
-  double ScaleFactor{0.0};
-  double RetractFactor{0.0};
-  double BattChargeLimit{0.0};
-  double BattDrawLimit{0.0};
-  double RPMStdDev{0.0};
-  double BiasCurrent{0.0};
-  int16_t Status{0};
+  float rpm{0.0};
+  float sd_rpm{0.0};  // TODO(anyone) not set
+  float voltage{0.0};
+  float draw_curr_limit{0.0};  // TODO(anyone) not set
+  float bcurrent{0.0};
+  float wcurrent{0.0};
+  float torque{0.0};  // TODO(anyone) not set
+  float diff_press{0.0};
+  float bias_current{0.0};  // TODO(anyone) not set
+  float loaddc{0.0};
+  float scale{0.0};
+  float retract{0.0};
+  float target_v{0.0};  // TODO(anyone) not set
+  float target_a{0.0};
+  int16_t status{0};  // TODO(anyone) not set
+  float charge_curr_limit{0.0};  // TODO(anyone) not set
+
+  buoy_utils::CommandTriState torque_command;
+  buoy_utils::CommandTriState scale_command;
+  buoy_utils::CommandTriState retract_command;
 };
 
-/// \brief A volume component where the units are m^3.
-/// Double value indicates volume of an entity.
-using PTO_State = ignition::gazebo::components::Component<ElectroHydraulicState,
+namespace components
+{
+/// \brief State data as component for power commands and feedback from sensors for PCRecord
+/// message in ROS2
+using ElectroHydraulicState =
+  ignition::gazebo::components::Component<buoy_gazebo::ElectroHydraulicState,
     class ElectroHydraulicStateTag>;
-IGN_GAZEBO_REGISTER_COMPONENT("buoy_gazebo.PTO_State", PTO_State)
+IGN_GAZEBO_REGISTER_COMPONENT(
+  "buoy_gazebo.components.ElectroHydraulicState",
+  ElectroHydraulicState)
+}  // namespace components
+
 }  // namespace buoy_gazebo
 
 #endif  // ELECTROHYDRAULICPTO__ELECTROHYDRAULICSTATE_HPP_

--- a/buoy_gazebo/src/ElectroHydraulicPTO/WindingCurrentTarget.hpp
+++ b/buoy_gazebo/src/ElectroHydraulicPTO/WindingCurrentTarget.hpp
@@ -48,7 +48,6 @@
 class WindingCurrentTarget
 {
 public:
-  // static constexpr double DEFAULT_SCALE_FACTOR;
   double TorqueConstantNMPerAmp;   // N-m/Amp
   double TorqueConstantInLbPerAmp;  // in-lb/Amp
   JustInterp::LinearInterpolator<double> DefaultDamping;

--- a/buoy_gazebo/src/ElectroHydraulicPTO/WindingCurrentTarget.hpp
+++ b/buoy_gazebo/src/ElectroHydraulicPTO/WindingCurrentTarget.hpp
@@ -48,6 +48,7 @@
 class WindingCurrentTarget
 {
 public:
+  // static constexpr double DEFAULT_SCALE_FACTOR;
   double TorqueConstantNMPerAmp;   // N-m/Amp
   double TorqueConstantInLbPerAmp;  // in-lb/Amp
   JustInterp::LinearInterpolator<double> DefaultDamping;
@@ -68,7 +69,7 @@ public:
   /// \brief mutex to protect jointVelCmd
   std::mutex UserCommandMutex;
 
-  WindingCurrentTarget(void)
+  WindingCurrentTarget()
   {
     std::vector<double> N {0.0, 300.0, 600.0, 1000.0, 1700.0, 4400.0, 6790.0};       // RPM
     std::vector<double> Torque {0.0, 0.0, 0.8, 2.9, 5.6, 9.8, 16.6};       // N-m

--- a/buoy_gazebo/src/PolytropicPneumaticSpring/CMakeLists.txt
+++ b/buoy_gazebo/src/PolytropicPneumaticSpring/CMakeLists.txt
@@ -4,6 +4,8 @@ set(GZ_MATH_VER ${ignition-math6_VERSION_MAJOR})
 gz_add_plugin(PolytropicPneumaticSpring
   SOURCES
     PolytropicPneumaticSpring.cpp
+  INCLUDE_DIRS
+    ..
   PUBLIC_LINK_LIBS
     ignition-math${GZ_MATH_VER}::ignition-math${GZ_MATH_VER}
 )

--- a/buoy_gazebo/src/PolytropicPneumaticSpring/PolytropicPneumaticSpring.cpp
+++ b/buoy_gazebo/src/PolytropicPneumaticSpring/PolytropicPneumaticSpring.cpp
@@ -429,7 +429,8 @@ void PolytropicPneumaticSpring::PreUpdate(
 
   // Create joint position component if one doesn't exist
   auto jointPosComp =
-    _ecm.Component<ignition::gazebo::components::JointPosition>(this->dataPtr->config_->jointEntity);
+    _ecm.Component<ignition::gazebo::components::JointPosition>(
+    this->dataPtr->config_->jointEntity);
   if (jointPosComp == nullptr) {
     _ecm.CreateComponent(
       this->dataPtr->config_->jointEntity, ignition::gazebo::components::JointPosition());
@@ -442,7 +443,8 @@ void PolytropicPneumaticSpring::PreUpdate(
 
   // Create joint velocity component if one doesn't exist
   auto jointVelComp =
-    _ecm.Component<ignition::gazebo::components::JointVelocity>(this->dataPtr->config_->jointEntity);
+    _ecm.Component<ignition::gazebo::components::JointVelocity>(
+    this->dataPtr->config_->jointEntity);
   if (jointVelComp == nullptr) {
     _ecm.CreateComponent(
       this->dataPtr->config_->jointEntity, ignition::gazebo::components::JointVelocity());

--- a/buoy_gazebo/src/PolytropicPneumaticSpring/PolytropicPneumaticSpring.cpp
+++ b/buoy_gazebo/src/PolytropicPneumaticSpring/PolytropicPneumaticSpring.cpp
@@ -208,7 +208,7 @@ void PolytropicPneumaticSpring::pumpOn(
   IGN_ASSERT(V1 >= this->dataPtr->config_->dead_volume, "volume of chamber must be >= dead volume");
   IGN_ASSERT(V2 >= this->dataPtr->config_->dead_volume, "volume of chamber must be >= dead volume");
 
-  const double dt_sec = dt_nano * 1e-9;
+  const double dt_sec = dt_nano * IGN_NANO_TO_SEC;
 
   // want piston to raise 2 inches per minute
   // so pump mass flow from upper chamber to lower

--- a/buoy_gazebo/src/PolytropicPneumaticSpring/PolytropicPneumaticSpring.cpp
+++ b/buoy_gazebo/src/PolytropicPneumaticSpring/PolytropicPneumaticSpring.cpp
@@ -205,7 +205,7 @@ void PolytropicPneumaticSpring::pumpOn(
   double mass_flow = this->dataPtr->pump_absement * this->dataPtr->pump_pressure;
   double delta_mass = dt_sec * mass_flow;  // kg of gas per step
 
-  ignerr << "pump -- delta mass from/to this chamber to/from other: " << delta_mass << " kg" <<
+  igndbg << "pump -- delta mass from/to this chamber to/from other: " << delta_mass << " kg" <<
     std::endl;
 
   IGN_ASSERT(V1 >= this->dataPtr->dead_volume, "volume of chamber must be >= dead volume");

--- a/buoy_gazebo/src/PolytropicPneumaticSpring/PolytropicPneumaticSpring.cpp
+++ b/buoy_gazebo/src/PolytropicPneumaticSpring/PolytropicPneumaticSpring.cpp
@@ -38,22 +38,23 @@ using namespace std::chrono_literals;
 
 namespace buoy_gazebo
 {
-
-struct PolytropicPneumaticSpringPrivate
+struct PolytropicPneumaticSpringConfig
 {
   /// \brief Name of cylinder
   std::string name;
 
-  bool is_upper;
+  bool is_upper{false};
 
   /// \brief is hysteresis present in piston travel direction
-  bool hysteresis{false};
+  bool hysteresis;
 
   /// \brief adiabatic index (gamma) == 1.4 for diatomic gas (e.g. N2)
-  const double adiabatic_index{1.4};
+  static constexpr double ADIABATIC_INDEX{1.4};
 
   /// \brief polytropic index
-  double n{adiabatic_index}, n1{adiabatic_index}, n2{adiabatic_index};
+  double n0{ADIABATIC_INDEX}, n1{ADIABATIC_INDEX}, n2{ADIABATIC_INDEX};
+
+  bool is_adiabatic{false};
 
   /// \brief piston stroke (m)
   double stroke{2.03};
@@ -76,8 +77,8 @@ struct PolytropicPneumaticSpringPrivate
   /// \brief pump differential pressure (Pa)
   double pump_pressure{49e-7};
 
-  /// \brief initial Pressure (Pa)
-  double P0{410240}, P1{410240}, P2{410240};
+  /// \brief mass flow of gas using pump (kg/s)
+  double pump_mass_flow{pump_absement * pump_pressure};
 
   /// \brief initial Temp (K)
   double T0{283.15};
@@ -88,29 +89,11 @@ struct PolytropicPneumaticSpringPrivate
   /// \brief specific heat of gas under constant pressure (kJ/(kg K))
   double c_p{1.04};
 
-  /// \brief initial Volume (m^3)
-  double V0{dead_volume}, V1{dead_volume}, V2{dead_volume};
-
-  /// \brief mass of gas (kg)
-  double mass{0.0};
-
   /// \brief c=mR(specific) (Pa*m^3)/K
   double c{0.0};
 
-  /// \brief current Volume (m^3)
-  double V{0.0};
-
-  /// \brief current Pressure of gas (Pa)
-  double P{0.0};
-
-  /// \brief current Temperature of gas (K)
-  double T{0.0};
-
-  /// \brief current Force of gas on piston (N)
-  double F{0.0};
-
-  /// \brief current rate of heat loss (Watts)
-  double Q_rate{0.0};
+  /// \brief initial Volume (m^3)
+  double V0{dead_volume}, V1{dead_volume}, V2{dead_volume};
 
   /// \brief move piston along prescribed velocity for sysID
   bool debug_prescribed_velocity{false};
@@ -119,7 +102,39 @@ struct PolytropicPneumaticSpringPrivate
   ignition::gazebo::Entity jointEntity;
 
   /// \brief Model interface
-  ignition::gazebo::Model model {ignition::gazebo::kNullEntity};
+  ignition::gazebo::Model model{ignition::gazebo::kNullEntity};
+};
+
+struct PolytropicPneumaticSpringPrivate
+{
+  /// \brief polytropic index
+  double n{PolytropicPneumaticSpringConfig::ADIABATIC_INDEX};
+
+  /// \brief initial Pressure (Pa)
+  double P0{410240}, P1{410240}, P2{410240};
+
+  /// \brief mass of gas (kg)
+  double mass{0.0};
+
+  /// \brief current Volume (m^3)
+  double V{0.0266};
+
+  /// \brief initial Volume (m^3)
+  double V0{0.0266};  // takes value from config
+
+  /// \brief current Pressure of gas (Pa)
+  double P{P0};
+
+  /// \brief current Temperature of gas (K)
+  double T{283.15};
+
+  /// \brief current Force of gas on piston (N)
+  double F{0.0};
+
+  /// \brief current rate of heat loss (Watts)
+  double Q_rate{0.0};
+
+  std::unique_ptr<const PolytropicPneumaticSpringConfig> config_{nullptr};
 };
 
 //////////////////////////////////////////////////
@@ -140,18 +155,21 @@ double SdfParamDouble(
 ////////////////////////////////////////////////
 void PolytropicPneumaticSpring::openValve(
   const int dt_nano, const double & pressure_diff,
-  double & P0, double & V0)
+  double & P0, const double & V0)
 {
-  double _P{0.0}, _V{this->dataPtr->dead_volume};  // dummy vars
+  double _P{0.0}, _V{this->dataPtr->config_->dead_volume};  // dummy vars
   openValve(dt_nano, pressure_diff, P0, V0, _P, _V);
 }
 
 void PolytropicPneumaticSpring::openValve(
   const int dt_nano, const double & pressure_diff,
-  double & P1, double & V1,
-  double & P2, double & V2)
+  double & P1, const double & V1,
+  double & P2, const double & V2)
 {
-  double dt_sec = dt_nano * IGN_NANO_TO_SEC;
+  IGN_ASSERT(V1 >= this->dataPtr->config_->dead_volume, "volume of chamber must be >= dead volume");
+  IGN_ASSERT(V2 >= this->dataPtr->config_->dead_volume, "volume of chamber must be >= dead volume");
+
+  const double dt_sec = dt_nano * IGN_NANO_TO_SEC;
 
   // want piston to drop 1 inch per second
   // so let mass flow from lower chamber to upper
@@ -159,91 +177,72 @@ void PolytropicPneumaticSpring::openValve(
 
   // P in Pascals (kg/(m*s^2)
   // multiply by absement (meter-seconds) to get mass_flow in kg/s
-  double mass_flow = this->dataPtr->valve_absement * pressure_diff;
-  double delta_mass = dt_sec * mass_flow;  // kg of gas per step
+  const double mass_flow = this->dataPtr->config_->valve_absement * pressure_diff;
+  const double delta_mass = dt_sec * mass_flow;  // kg of gas per step
 
-  igndbg << "valve -- pressure differential: " << pressure_diff << " Pascal" << std::endl;
-  igndbg << "valve -- delta mass from/to this chamber to/from other: " << delta_mass << " kg" <<
-    std::endl;
-
-  IGN_ASSERT(V1 >= this->dataPtr->dead_volume, "volume of chamber must be >= dead volume");
-  IGN_ASSERT(V2 >= this->dataPtr->dead_volume, "volume of chamber must be >= dead volume");
-
-  if (this->dataPtr->is_upper) {
+  if (this->dataPtr->config_->is_upper) {
     this->dataPtr->mass += delta_mass;
-    P1 = this->dataPtr->mass * this->dataPtr->R * this->dataPtr->T0 / V1;
-    P2 = this->dataPtr->mass * this->dataPtr->R * this->dataPtr->T0 / V2;
   } else {
     this->dataPtr->mass -= delta_mass;
-    P1 = this->dataPtr->mass * this->dataPtr->R * this->dataPtr->T0 / V1;
-    P2 = this->dataPtr->mass * this->dataPtr->R * this->dataPtr->T0 / V2;
   }
+
+  const double mRT0 = this->dataPtr->mass * this->dataPtr->config_->R * this->dataPtr->config_->T0;
+  P1 = mRT0 / V1;
+  P2 = mRT0 / V2;
 }
 
 ////////////////////////////////////////////////
 void PolytropicPneumaticSpring::pumpOn(
   const int dt_nano,
-  double & P0, double & V0)
+  double & P0, const double & V0)
 {
-  double _P{0.0}, _V{this->dataPtr->dead_volume};  // dummy vars
+  double _P{0.0}, _V{this->dataPtr->config_->dead_volume};  // dummy vars
   pumpOn(dt_nano, P0, V0, _P, _V);
 }
 
 void PolytropicPneumaticSpring::pumpOn(
   const int dt_nano,
-  double & P1, double & V1,
-  double & P2, double & V2)
+  double & P1, const double & V1,
+  double & P2, const double & V2)
 {
-  double dt_sec = dt_nano * 1e-9;
+  IGN_ASSERT(V1 >= this->dataPtr->config_->dead_volume, "volume of chamber must be >= dead volume");
+  IGN_ASSERT(V2 >= this->dataPtr->config_->dead_volume, "volume of chamber must be >= dead volume");
+
+  const double dt_sec = dt_nano * 1e-9;
 
   // want piston to raise 2 inches per minute
   // so pump mass flow from upper chamber to lower
   // results in initial pressure change (P0 -- or P1, P2 with hysteresis) via ideal gas law
 
-  // pump pressure in Pascals (kg/(m*s^2)
-  // multiply by absement (meter-seconds) to get mass_flow in kg/s
-  double mass_flow = this->dataPtr->pump_absement * this->dataPtr->pump_pressure;
-  double delta_mass = dt_sec * mass_flow;  // kg of gas per step
+  const double delta_mass = dt_sec * this->dataPtr->config_->pump_mass_flow;  // kg of gas per step
 
-  igndbg << "pump -- delta mass from/to this chamber to/from other: " << delta_mass << " kg" <<
-    std::endl;
-
-  IGN_ASSERT(V1 >= this->dataPtr->dead_volume, "volume of chamber must be >= dead volume");
-  IGN_ASSERT(V2 >= this->dataPtr->dead_volume, "volume of chamber must be >= dead volume");
-
-  if (this->dataPtr->is_upper) {
+  if (this->dataPtr->config_->is_upper) {
     this->dataPtr->mass -= delta_mass;
-    P1 = this->dataPtr->mass * this->dataPtr->R * this->dataPtr->T0 / V1;
-    P2 = this->dataPtr->mass * this->dataPtr->R * this->dataPtr->T0 / V2;
   } else {
     this->dataPtr->mass += delta_mass;
-    P1 = this->dataPtr->mass * this->dataPtr->R * this->dataPtr->T0 / V1;
-    P2 = this->dataPtr->mass * this->dataPtr->R * this->dataPtr->T0 / V2;
   }
+
+  const double mRT0 = this->dataPtr->mass * this->dataPtr->config_->R * this->dataPtr->config_->T0;
+  P1 = mRT0 / V1;
+  P2 = mRT0 / V2;
 }
 
 //////////////////////////////////////////////////
-void PolytropicPneumaticSpring::computeForce(const double & x, const double & v, const double & n)
+void PolytropicPneumaticSpring::computeForce(const double & x, const double & v)
 {
-  this->dataPtr->V = this->dataPtr->dead_volume + x * this->dataPtr->piston_area;
+  this->dataPtr->V = this->dataPtr->config_->dead_volume + x * this->dataPtr->config_->piston_area;
   this->dataPtr->P = this->dataPtr->P0 *
     pow(this->dataPtr->V0 / this->dataPtr->V, this->dataPtr->n);
-  this->dataPtr->T = this->dataPtr->P * this->dataPtr->V / this->dataPtr->c;
+  this->dataPtr->T = this->dataPtr->P * this->dataPtr->V / this->dataPtr->config_->c;
 
-  if (fabs(n - this->dataPtr->adiabatic_index) < 1.0e-7) {
-    this->dataPtr->Q_rate = 0.0;
-  } else {
+  static const double cp_R = this->dataPtr->config_->c_p / this->dataPtr->config_->R;
+  if (!this->dataPtr->config_->is_adiabatic) {
     this->dataPtr->Q_rate = \
-      (1.0 - n / this->dataPtr->adiabatic_index) * \
-      (this->dataPtr->c_p / this->dataPtr->R) * \
-      this->dataPtr->P * this->dataPtr->piston_area * v;
+      (1.0 - this->dataPtr->n / PolytropicPneumaticSpringConfig::ADIABATIC_INDEX) * cp_R * \
+      this->dataPtr->P * this->dataPtr->config_->piston_area * v;
   }
 
-  this->dataPtr->F = this->dataPtr->P * this->dataPtr->piston_area;
-
-  igndbg << "V (" << this->dataPtr->name << "):" << this->dataPtr->V << std::endl;
-  igndbg << "P (" << this->dataPtr->name << "):" << this->dataPtr->P << std::endl;
-  igndbg << "T (" << this->dataPtr->name << "):" << this->dataPtr->T << std::endl;
+  this->dataPtr->F = this->dataPtr->P * this->dataPtr->config_->piston_area;
 }
 
 //////////////////////////////////////////////////
@@ -253,61 +252,82 @@ void PolytropicPneumaticSpring::Configure(
   ignition::gazebo::EntityComponentManager & _ecm,
   ignition::gazebo::EventManager & /*_eventMgr*/)
 {
-  this->dataPtr->name = _sdf->Get<std::string>("chamber", "upper_adiabatic").first;
-  igndbg << "name: " << this->dataPtr->name << std::endl;
+  PolytropicPneumaticSpringConfig config;
 
-  this->dataPtr->is_upper = _sdf->Get<bool>("is_upper");
-  igndbg << "is upper? " << std::boolalpha << this->dataPtr->is_upper << std::noboolalpha <<
-    std::endl;
+  config.name = _sdf->Get<std::string>("chamber", "upper_adiabatic").first;
+  igndbg << "name: " << config.name << std::endl;
 
-  this->dataPtr->valve_absement = SdfParamDouble(_sdf, "valve_absement", 49e-7);
-  this->dataPtr->pump_absement = SdfParamDouble(_sdf, "pump_absement", 11e-7);
-  this->dataPtr->pump_pressure = SdfParamDouble(_sdf, "pump_pressure", 1.7e+6);
-  this->dataPtr->stroke = SdfParamDouble(_sdf, "stroke", 2.03);
-  this->dataPtr->piston_area = SdfParamDouble(_sdf, "piston_area", 0.0127);
-  this->dataPtr->dead_volume = SdfParamDouble(_sdf, "dead_volume", 0.0266);
-  this->dataPtr->T0 = SdfParamDouble(_sdf, "T0", 283.15);
-  this->dataPtr->R = SdfParamDouble(_sdf, "R_specific", 0.2968);
-  this->dataPtr->c_p = SdfParamDouble(_sdf, "c_p", 1.04);
-  this->dataPtr->debug_prescribed_velocity = _sdf->Get<bool>(
+  config.is_upper = _sdf->Get<bool>("is_upper");
+  igndbg << "is upper? " << std::boolalpha << config.is_upper << std::noboolalpha << std::endl;
+
+  config.valve_absement = SdfParamDouble(_sdf, "valve_absement", config.valve_absement);
+  config.pump_absement = SdfParamDouble(_sdf, "pump_absement", config.pump_absement);
+  config.pump_pressure = SdfParamDouble(_sdf, "pump_pressure", config.pump_pressure);
+  // pump pressure in Pascals (kg/(m*s^2)
+  // multiply by absement (meter-seconds) to get mass_flow in kg/s
+  config.pump_mass_flow = config.pump_absement * config.pump_pressure;
+
+  config.stroke = SdfParamDouble(_sdf, "stroke", config.stroke);
+  config.piston_area = SdfParamDouble(_sdf, "piston_area", config.piston_area);
+  config.dead_volume = SdfParamDouble(_sdf, "dead_volume", config.dead_volume);
+  config.R = SdfParamDouble(_sdf, "R_specific", config.R);
+  config.c_p = SdfParamDouble(_sdf, "c_p", config.c_p);
+  config.debug_prescribed_velocity = _sdf->Get<bool>(
     "debug_prescribed_velocity", false).first;
+  config.T0 = SdfParamDouble(_sdf, "T0", config.T0);
 
-  this->dataPtr->hysteresis = _sdf->Get<bool>("hysteresis", false).first;
-  if (this->dataPtr->hysteresis) {
-    this->dataPtr->n1 = SdfParamDouble(_sdf, "n1", this->dataPtr->adiabatic_index);
-    this->dataPtr->n2 = SdfParamDouble(_sdf, "n2", this->dataPtr->adiabatic_index);
-    this->dataPtr->P1 = SdfParamDouble(_sdf, "P1", 410240);
-    this->dataPtr->P2 = SdfParamDouble(_sdf, "P2", 410240);
-    this->dataPtr->x1 = SdfParamDouble(_sdf, "x1", 0.9921);
-    this->dataPtr->x2 = SdfParamDouble(_sdf, "x2", 0.9921);
+  config.hysteresis = _sdf->Get<bool>("hysteresis", false).first;
+  if (config.hysteresis) {
+    config.n1 = SdfParamDouble(_sdf, "n1", PolytropicPneumaticSpringConfig::ADIABATIC_INDEX);
+    config.n2 = SdfParamDouble(_sdf, "n2", PolytropicPneumaticSpringConfig::ADIABATIC_INDEX);
+    if ((fabs(config.n1 - PolytropicPneumaticSpringConfig::ADIABATIC_INDEX) < 1.0e-7) && \
+      (fabs(config.n2 - PolytropicPneumaticSpringConfig::ADIABATIC_INDEX) < 1.0e-7))
+    {
+      config.is_adiabatic = true;
+    } else {
+      config.is_adiabatic = false;
+    }
+    this->dataPtr->n = config.n1;
+    this->dataPtr->P1 = SdfParamDouble(_sdf, "P1", this->dataPtr->P1);
+    this->dataPtr->P2 = SdfParamDouble(_sdf, "P2", this->dataPtr->P2);
+    config.x1 = SdfParamDouble(_sdf, "x1", config.x1);
+    config.x2 = SdfParamDouble(_sdf, "x2", config.x2);
 
-    this->dataPtr->V1 = this->dataPtr->dead_volume + \
-      this->dataPtr->x1 * this->dataPtr->piston_area;
-    igndbg << "V1: " << this->dataPtr->V1 << std::endl;
-    this->dataPtr->V2 = this->dataPtr->dead_volume + \
-      this->dataPtr->x2 * this->dataPtr->piston_area;
-    igndbg << "V2: " << this->dataPtr->V2 << std::endl;
+    config.V1 = config.dead_volume + \
+      config.x1 * config.piston_area;
+    igndbg << "V1: " << config.V1 << std::endl;
+    config.V2 = config.dead_volume + \
+      config.x2 * config.piston_area;
+    igndbg << "V2: " << config.V2 << std::endl;
+    this->dataPtr->V0 = config.V1;
 
-    this->dataPtr->c = this->dataPtr->P1 * this->dataPtr->V1 / this->dataPtr->T0;
-    igndbg << "c: " << this->dataPtr->c << std::endl;
-    this->dataPtr->mass = this->dataPtr->c / this->dataPtr->R;
+    config.c = this->dataPtr->P1 * config.V1 / config.T0;
+    igndbg << "c: " << config.c << std::endl;
+    this->dataPtr->mass = config.c / config.R;
     igndbg << "mass: " << this->dataPtr->mass << std::endl;
-  } else {
-    this->dataPtr->n = SdfParamDouble(_sdf, "n", this->dataPtr->adiabatic_index);
-    this->dataPtr->P0 = SdfParamDouble(_sdf, "P0", 410240);
-    this->dataPtr->x0 = SdfParamDouble(_sdf, "x0", 0.9921);
-    this->dataPtr->V0 = this->dataPtr->dead_volume + \
-      this->dataPtr->x0 * this->dataPtr->piston_area;
+  } else {  // no hysteresis
+    config.n0 = SdfParamDouble(_sdf, "n", PolytropicPneumaticSpringConfig::ADIABATIC_INDEX);
+    if (fabs(config.n0 - PolytropicPneumaticSpringConfig::ADIABATIC_INDEX) < 1.0e-7) {
+      config.is_adiabatic = true;
+    } else {
+      config.is_adiabatic = false;
+    }
+    this->dataPtr->n = config.n0;
+    this->dataPtr->P0 = SdfParamDouble(_sdf, "P0", this->dataPtr->P0);
+    config.x0 = SdfParamDouble(_sdf, "x0", config.x0);
+    config.V0 = config.dead_volume + \
+      config.x0 * config.piston_area;
+    this->dataPtr->V0 = config.V0;
 
-    igndbg << "V0: " << this->dataPtr->V0 << std::endl;
-    this->dataPtr->c = this->dataPtr->P0 * this->dataPtr->V0 / this->dataPtr->T0;
-    igndbg << "c: " << this->dataPtr->c << std::endl;
-    this->dataPtr->mass = this->dataPtr->c / this->dataPtr->R;
+    igndbg << "V0: " << config.V0 << std::endl;
+    config.c = this->dataPtr->P0 * config.V0 / config.T0;
+    igndbg << "c: " << config.c << std::endl;
+    this->dataPtr->mass = config.c / config.R;
     igndbg << "mass: " << this->dataPtr->mass << std::endl;
   }
 
-  this->dataPtr->model = ignition::gazebo::Model(_entity);
-  if (!this->dataPtr->model.Valid(_ecm)) {
+  config.model = ignition::gazebo::Model(_entity);
+  if (!config.model.Valid(_ecm)) {
     ignerr << "PolytropicPneumaticSpring plugin should be attached to a model entity. " <<
       "Failed to initialize." << std::endl;
     return;
@@ -321,16 +341,18 @@ void PolytropicPneumaticSpring::Configure(
     return;
   }
 
-  this->dataPtr->jointEntity = this->dataPtr->model.JointByName(
+  config.jointEntity = config.model.JointByName(
     _ecm,
     jointName);
-  if (this->dataPtr->jointEntity == ignition::gazebo::kNullEntity) {
+  if (config.jointEntity == ignition::gazebo::kNullEntity) {
     ignerr << "Joint with name[" << jointName << "] not found. " <<
       "The PolytropicPneumaticSpring may not influence this joint.\n";
     return;
   }
 
-  std::string force_topic = std::string("/force_") + this->dataPtr->name;
+  this->dataPtr->config_ = std::make_unique<const PolytropicPneumaticSpringConfig>(config);
+
+  std::string force_topic = std::string("/force_") + this->dataPtr->config_->name;
   force_pub = \
     node.Advertise<ignition::msgs::Double>(
     ignition::transport::TopicUtils::AsValidTopic(
@@ -340,7 +362,7 @@ void PolytropicPneumaticSpring::Configure(
     return;
   }
 
-  std::string pressure_topic = std::string("/pressure_") + this->dataPtr->name;
+  std::string pressure_topic = std::string("/pressure_") + this->dataPtr->config_->name;
   pressure_pub = \
     node.Advertise<ignition::msgs::Double>(
     ignition::transport::TopicUtils::AsValidTopic(
@@ -350,7 +372,7 @@ void PolytropicPneumaticSpring::Configure(
     return;
   }
 
-  std::string volume_topic = std::string("/volume_") + this->dataPtr->name;
+  std::string volume_topic = std::string("/volume_") + this->dataPtr->config_->name;
   volume_pub = \
     node.Advertise<ignition::msgs::Double>(
     ignition::transport::TopicUtils::AsValidTopic(
@@ -360,7 +382,7 @@ void PolytropicPneumaticSpring::Configure(
     return;
   }
 
-  std::string temperature_topic = std::string("/temperature_") + this->dataPtr->name;
+  std::string temperature_topic = std::string("/temperature_") + this->dataPtr->config_->name;
   temperature_pub = \
     node.Advertise<ignition::msgs::Double>(
     ignition::transport::TopicUtils::AsValidTopic(
@@ -370,7 +392,7 @@ void PolytropicPneumaticSpring::Configure(
     return;
   }
 
-  std::string heat_rate_topic = std::string("/heat_rate_") + this->dataPtr->name;
+  std::string heat_rate_topic = std::string("/heat_rate_") + this->dataPtr->config_->name;
   heat_rate_pub = \
     node.Advertise<ignition::msgs::Double>(
     ignition::transport::TopicUtils::AsValidTopic(
@@ -378,17 +400,6 @@ void PolytropicPneumaticSpring::Configure(
   if (!heat_rate_pub) {
     ignerr << "Error advertising topic [" << heat_rate_topic << "]" << std::endl;
     return;
-  }
-
-  if (this->dataPtr->is_upper) {
-    std::string piston_velocity_topic = std::string("/piston_velocity_") + this->dataPtr->name;
-    piston_velocity_pub = \
-      node.Advertise<ignition::msgs::Double>(
-      ignition::transport::TopicUtils::AsValidTopic(piston_velocity_topic));
-    if (!piston_velocity_pub) {
-      ignerr << "Error advertising topic [" << piston_velocity_topic << "]" << std::endl;
-      return;
-    }
   }
 }
 
@@ -400,7 +411,7 @@ void PolytropicPneumaticSpring::PreUpdate(
   IGN_PROFILE("PolytropicPneumaticSpring::PreUpdate");
 
   // If the joint hasn't been identified yet, the plugin is disabled
-  if (this->dataPtr->jointEntity == ignition::gazebo::kNullEntity) {
+  if (this->dataPtr->config_->jointEntity == ignition::gazebo::kNullEntity) {
     return;
   }
 
@@ -418,10 +429,10 @@ void PolytropicPneumaticSpring::PreUpdate(
 
   // Create joint position component if one doesn't exist
   auto jointPosComp =
-    _ecm.Component<ignition::gazebo::components::JointPosition>(this->dataPtr->jointEntity);
+    _ecm.Component<ignition::gazebo::components::JointPosition>(this->dataPtr->config_->jointEntity);
   if (jointPosComp == nullptr) {
     _ecm.CreateComponent(
-      this->dataPtr->jointEntity, ignition::gazebo::components::JointPosition());
+      this->dataPtr->config_->jointEntity, ignition::gazebo::components::JointPosition());
   }
   // We just created the joint position component, give one iteration for the
   // physics system to update its size
@@ -431,10 +442,10 @@ void PolytropicPneumaticSpring::PreUpdate(
 
   // Create joint velocity component if one doesn't exist
   auto jointVelComp =
-    _ecm.Component<ignition::gazebo::components::JointVelocity>(this->dataPtr->jointEntity);
+    _ecm.Component<ignition::gazebo::components::JointVelocity>(this->dataPtr->config_->jointEntity);
   if (jointVelComp == nullptr) {
     _ecm.CreateComponent(
-      this->dataPtr->jointEntity, ignition::gazebo::components::JointVelocity());
+      this->dataPtr->config_->jointEntity, ignition::gazebo::components::JointVelocity());
   }
   // We just created the joint velocity component, give one iteration for the
   // physics system to update its size
@@ -444,11 +455,11 @@ void PolytropicPneumaticSpring::PreUpdate(
 
   buoy_gazebo::SpringState spring_state;
   if (_ecm.EntityHasComponentType(
-      this->dataPtr->jointEntity,
+      this->dataPtr->config_->jointEntity,
       buoy_gazebo::components::SpringState().TypeId()))
   {
     auto spring_state_comp = \
-      _ecm.Component<buoy_gazebo::components::SpringState>(this->dataPtr->jointEntity);
+      _ecm.Component<buoy_gazebo::components::SpringState>(this->dataPtr->config_->jointEntity);
 
     spring_state = buoy_gazebo::SpringState(spring_state_comp->Data());
   }
@@ -457,45 +468,38 @@ void PolytropicPneumaticSpring::PreUpdate(
   // some OR code has a process of finding the index for this argument.
   double x = jointPosComp->Data().at(0);
   double v = jointVelComp->Data().at(0);
-  igndbg << "velocity: " << v << std::endl;
-  if (this->dataPtr->is_upper) {
-    x = this->dataPtr->stroke - x;
+
+  if (this->dataPtr->config_->is_upper) {
+    x = this->dataPtr->config_->stroke - x;
     v *= -1.0;
-    igndbg << "swap direction (" << this->dataPtr->name << ")" << std::endl;
   }
 
-  int dt_nano = \
+  const int dt_nano = \
     static_cast<int>(std::chrono::duration_cast<std::chrono::nanoseconds>(_info.dt).count());
 
-  const double PASCAL_TO_PSI = 1.450377e-4;  // PSI/Pascal
+  static const double PASCAL_TO_PSI = 1.450377e-4;  // PSI/Pascal
   const double pressure_diff = (spring_state.lower_psi - spring_state.upper_psi) / PASCAL_TO_PSI;
 
-  if (this->dataPtr->hysteresis) {
-    igndbg << "hysteresis (" << this->dataPtr->name << "): " <<
-      this->dataPtr->hysteresis << std::endl;
+  if (this->dataPtr->config_->hysteresis) {
     if (spring_state.valve_command) {
       openValve(
         dt_nano, pressure_diff,
-        this->dataPtr->P1, this->dataPtr->V1,
-        this->dataPtr->P2, this->dataPtr->V2);
+        this->dataPtr->P1, this->dataPtr->config_->V1,
+        this->dataPtr->P2, this->dataPtr->config_->V2);
     } else if (spring_state.pump_command) {
       pumpOn(
         dt_nano,
-        this->dataPtr->P1, this->dataPtr->V1,
-        this->dataPtr->P2, this->dataPtr->V2);
+        this->dataPtr->P1, this->dataPtr->config_->V1,
+        this->dataPtr->P2, this->dataPtr->config_->V2);
     }
 
     if (v >= 0.0) {
-      this->dataPtr->n = this->dataPtr->n1;
-      igndbg << "polytropic index for increasing volume (" << this->dataPtr->name << "): " <<
-        this->dataPtr->n << std::endl;
-      this->dataPtr->V0 = this->dataPtr->V1;
+      this->dataPtr->n = this->dataPtr->config_->n1;
+      this->dataPtr->V0 = this->dataPtr->config_->V1;
       this->dataPtr->P0 = this->dataPtr->P1;
     } else {
-      this->dataPtr->n = this->dataPtr->n2;
-      igndbg << "polytropic index for decreasing volume (" << this->dataPtr->name << "): " <<
-        this->dataPtr->n << std::endl;
-      this->dataPtr->V0 = this->dataPtr->V2;
+      this->dataPtr->n = this->dataPtr->config_->n2;
+      this->dataPtr->V0 = this->dataPtr->config_->V2;
       this->dataPtr->P0 = this->dataPtr->P2;
     }
   } else {
@@ -510,19 +514,14 @@ void PolytropicPneumaticSpring::PreUpdate(
     }
   }
 
-  // TODO(anyone): use sensor to access to P (pressure sensor) and T (thermometer)
-  computeForce(x, v, this->dataPtr->n);
-  if (this->dataPtr->is_upper) {
+  computeForce(x, v);
+  if (this->dataPtr->config_->is_upper) {
     this->dataPtr->F *= -1.0;
-    igndbg << "swap F for direction of piston (" << this->dataPtr->name << "): " <<
-      this->dataPtr->F << std::endl;
-  } else {
-    igndbg << "F (" << this->dataPtr->name << "):" << this->dataPtr->F << std::endl;
   }
 
   auto stampMsg = ignition::gazebo::convert<ignition::msgs::Time>(_info.simTime);
 
-  if (this->dataPtr->is_upper) {
+  if (this->dataPtr->config_->is_upper) {
     spring_state.range_finder = x;
     spring_state.upper_psi = PASCAL_TO_PSI * this->dataPtr->P;
   } else {
@@ -530,13 +529,14 @@ void PolytropicPneumaticSpring::PreUpdate(
   }
 
   _ecm.SetComponentData<buoy_gazebo::components::SpringState>(
-    this->dataPtr->jointEntity,
+    this->dataPtr->config_->jointEntity,
     spring_state);
 
   ignition::msgs::Double force;
   force.mutable_header()->mutable_stamp()->CopyFrom(stampMsg);
   force.set_data(this->dataPtr->F);
 
+  // TODO(anyone): use sensor to access to P (pressure sensor) and T (thermometer)
   ignition::msgs::Double pressure;
   pressure.mutable_header()->mutable_stamp()->CopyFrom(stampMsg);
   pressure.set_data(this->dataPtr->P);
@@ -577,33 +577,29 @@ void PolytropicPneumaticSpring::PreUpdate(
     ignerr << "could not publish heat loss rate" << std::endl;
   }
 
-  if (this->dataPtr->is_upper) {
-    if (!piston_velocity_pub.Publish(piston_velocity)) {
-      ignerr << "could not publish piston velocity" << std::endl;
-    }
-  }
-
-  if (!this->dataPtr->debug_prescribed_velocity) {
+  static const bool debug_prescribed_velocity{this->dataPtr->config_->debug_prescribed_velocity};
+  if (!debug_prescribed_velocity) {
     auto forceComp =
-      _ecm.Component<ignition::gazebo::components::JointForceCmd>(this->dataPtr->jointEntity);
+      _ecm.Component<ignition::gazebo::components::JointForceCmd>(
+      this->dataPtr->config_->jointEntity);
     if (forceComp == nullptr) {
       _ecm.CreateComponent(
-        this->dataPtr->jointEntity,
+        this->dataPtr->config_->jointEntity,
         ignition::gazebo::components::JointForceCmd({this->dataPtr->F}));
     } else {
-      forceComp->Data()[0] += this->dataPtr->F;    // Add force to existing forces.
+      forceComp->Data()[0] += this->dataPtr->F;  // Add force to existing forces.
     }
   } else {
-    double period = 2.0;    // sec
+    double period = 2.0;  // sec
 
-    double piston_velocity = this->dataPtr->stroke * cos(
-      2.0 * 3.14159265358979 *
+    double piston_velocity = this->dataPtr->config_->stroke * cos(
+      2.0 * IGN_PI *
       std::chrono::duration_cast<std::chrono::seconds>(_info.simTime).count() / period);
     auto joint_vel = _ecm.Component<ignition::gazebo::components::JointVelocityCmd>(
-      this->dataPtr->jointEntity);
+      this->dataPtr->config_->jointEntity);
     if (joint_vel == nullptr) {
       _ecm.CreateComponent(
-        this->dataPtr->jointEntity,
+        this->dataPtr->config_->jointEntity,
         ignition::gazebo::components::JointVelocityCmd({piston_velocity}));
     } else {
       *joint_vel = ignition::gazebo::components::JointVelocityCmd({piston_velocity});

--- a/buoy_gazebo/src/PolytropicPneumaticSpring/PolytropicPneumaticSpring.cpp
+++ b/buoy_gazebo/src/PolytropicPneumaticSpring/PolytropicPneumaticSpring.cpp
@@ -72,10 +72,10 @@ struct PolytropicPneumaticSpringConfig
   double valve_absement{49e-7};
 
   /// \brief measure of pump opening cross-section and duration (meter-seconds)
-  double pump_absement{11e-7};
+  double pump_absement{10e-8};
 
   /// \brief pump differential pressure (Pa)
-  double pump_pressure{49e-7};
+  double pump_pressure{1.7e+6};
 
   /// \brief mass flow of gas using pump (kg/s)
   double pump_mass_flow{pump_absement * pump_pressure};

--- a/buoy_gazebo/src/PolytropicPneumaticSpring/PolytropicPneumaticSpring.cpp
+++ b/buoy_gazebo/src/PolytropicPneumaticSpring/PolytropicPneumaticSpring.cpp
@@ -33,6 +33,8 @@
 #include <mutex>
 #include <string>
 
+#include "SpringState.hpp"
+
 
 using namespace std::chrono_literals;
 

--- a/buoy_gazebo/src/PolytropicPneumaticSpring/PolytropicPneumaticSpring.hpp
+++ b/buoy_gazebo/src/PolytropicPneumaticSpring/PolytropicPneumaticSpring.hpp
@@ -28,9 +28,32 @@ namespace buoy_gazebo
 // Forward declaration
 struct PolytropicPneumaticSpringPrivate;
 
-/// TODO(andermi) documentation
 /// SDF parameters:
-/// * `<>`:
+/// \brief
+/// * `<JointName>`: joint the plugin is attached to
+/// * `<chamber>`: name of chamber
+/// * `<is_upper>`: is this the upper chamber?
+/// * `<valve_absement>`: measure of valve opening cross-section and duration (meter-seconds)
+/// * `<pump_absement>`: measure of pump opening cross-section and duration (meter-seconds)
+/// * `<pump_pressure>`: pump differential pressure
+/// * `<stroke>`: piston stroke (m)
+/// * `<piston_area>`: piston area (m^3)
+/// * `<dead_volume>`: Piston-End Dead Volume (m^3)
+/// * `<T0>`: initial Temp (K)
+/// * `<R_specific>`: R (specific gas) constant
+/// * `<c_p>`: specific heat of gas under constant pressure (kJ/(kg K))
+/// * `<hysteresis>`: is hysteresis present in piston travel direction
+/// * `<n>`: polytropic index
+/// * `<n1>`: polytropic index for increasing volume (if hysteresis)
+/// * `<n2>`: polytropic index for decreasing volume (if hysteresis)
+/// * `<x0>`: initial piston position (m)
+/// * `<x1>`: initial piston position (m) for increasing volume (if hysteresis)
+/// * `<x2>`: initial piston position (m) for decreasing volume (if hysteresis)
+/// * `<P0>`: initial Pressure (Pa)
+/// * `<P1>`: initial Pressure (Pa) for increasing volume (if hysteresis)
+/// * `<P2>`: initial Pressure (Pa) for decreasing volume (if hysteresis)
+/// * `<debug_prescribed_velocity>`: will force joint to move sinusoidally for debugging
+
 class PolytropicPneumaticSpring : public ignition::gazebo::System,
   public ignition::gazebo::ISystemConfigure,
   public ignition::gazebo::ISystemPreUpdate
@@ -55,16 +78,20 @@ public:
     ignition::gazebo::EntityComponentManager & _ecm) override;
 
 private:
+  /// \brief open valve to vent gas from lower to upper chamber
   void openValve(
     const int dt_nano, const double & pressure_diff,
     double & P0, const double & V0);
+  /// \brief (with hysteresis) open valve to vent gas from lower to upper chamber
   void openValve(
     const int dt_nano, const double & pressure_diff,
     double & P1, const double & V1,
     double & P2, const double & V2);
+  /// \brief pump gas from upper to lower chamber
   void pumpOn(
     const int dt_nano,
     double & P0, const double & V0);
+  /// \brief (with hysteresis) pump gas from upper to lower chamber
   void pumpOn(
     const int dt_nano,
     double & P1, const double & V1,

--- a/buoy_gazebo/src/PolytropicPneumaticSpring/PolytropicPneumaticSpring.hpp
+++ b/buoy_gazebo/src/PolytropicPneumaticSpring/PolytropicPneumaticSpring.hpp
@@ -30,7 +30,7 @@ struct PolytropicPneumaticSpringPrivate;
 
 /// TODO(andermi) documentation
 /// SDF parameters:
-/// * `<>`: 
+/// * `<>`:
 class PolytropicPneumaticSpring : public ignition::gazebo::System,
   public ignition::gazebo::ISystemConfigure,
   public ignition::gazebo::ISystemPreUpdate

--- a/buoy_gazebo/src/PolytropicPneumaticSpring/PolytropicPneumaticSpring.hpp
+++ b/buoy_gazebo/src/PolytropicPneumaticSpring/PolytropicPneumaticSpring.hpp
@@ -20,8 +20,6 @@
 
 #include <memory>
 
-#include "SpringState.hpp"
-
 
 namespace buoy_gazebo
 {

--- a/buoy_gazebo/src/PolytropicPneumaticSpring/PolytropicPneumaticSpring.hpp
+++ b/buoy_gazebo/src/PolytropicPneumaticSpring/PolytropicPneumaticSpring.hpp
@@ -57,19 +57,19 @@ public:
 private:
   void openValve(
     const int dt_nano, const double & pressure_diff,
-    double & P0, double & V0);
+    double & P0, const double & V0);
   void openValve(
     const int dt_nano, const double & pressure_diff,
-    double & P1, double & V1,
-    double & P2, double & V2);
+    double & P1, const double & V1,
+    double & P2, const double & V2);
   void pumpOn(
     const int dt_nano,
-    double & P0, double & V0);
+    double & P0, const double & V0);
   void pumpOn(
     const int dt_nano,
-    double & P1, double & V1,
-    double & P2, double & V2);
-  void computeForce(const double & x, const double & v, const double & n);
+    double & P1, const double & V1,
+    double & P2, const double & V2);
+  void computeForce(const double & x, const double & v);
 
   ignition::transport::Node node;
   ignition::transport::Node::Publisher force_pub, pressure_pub, volume_pub,

--- a/buoy_gazebo/src/PolytropicPneumaticSpring/SpringState.hpp
+++ b/buoy_gazebo/src/PolytropicPneumaticSpring/SpringState.hpp
@@ -42,9 +42,10 @@ struct SpringState
   bool operator==(const SpringState & that) const
   {
     bool equal = this->load_cell == that.load_cell;
-    equal &= fabs(this->range_finder - that.range_finder) < 1e-7;
-    equal &= fabs(this->upper_psi - that.upper_psi) < 1e-7;
-    equal &= fabs(this->lower_psi - that.lower_psi) < 1e-7;
+    equal &= fabs(this->range_finder - that.range_finder) < 1e-7F;
+    equal &= fabs(this->upper_psi - that.upper_psi) < 1e-7F;
+    equal &= fabs(this->lower_psi - that.lower_psi) < 1e-7F;
+    equal &= this->status == that.status;
     return equal;
   }
 };

--- a/buoy_gazebo/src/PolytropicPneumaticSpring/SpringState.hpp
+++ b/buoy_gazebo/src/PolytropicPneumaticSpring/SpringState.hpp
@@ -76,6 +76,7 @@ struct SpringState
   float range_finder{0.0F};  // position in meters (TODO(andermi) for now)
   float upper_psi{0.0F};  // pressure in PSI
   float lower_psi{0.0F};  // pressure in PSI
+  int16_t status{0};  // TODO(andermi) status bit field
 
   // Commands
   CommandTriState valve_command;

--- a/buoy_gazebo/src/PolytropicPneumaticSpring/SpringState.hpp
+++ b/buoy_gazebo/src/PolytropicPneumaticSpring/SpringState.hpp
@@ -19,54 +19,10 @@
 #include <ignition/gazebo/components/Component.hh>
 #include <ignition/gazebo/config.hh>
 
+#include <buoy_utils/CommandTriState.hpp>
+
 namespace buoy_gazebo
 {
-/// \brief Command state variable that tracks if command is running, finished, or ever was active
-struct CommandTriState
-{
-  bool left{false};
-  bool right{false};
-
-  bool isRunning() const  // rising edge
-  {
-    return !left && right;
-  }
-
-  bool isFinished() const  // falling edge
-  {
-    return left && !right;
-  }
-
-  bool active() const  // running or finished
-  {
-    return left || right;
-  }
-
-  operator bool() const
-  {
-    return isRunning();
-  }
-
-  void reset()
-  {
-    left = right = false;  // no command activity
-  }
-
-  void operator=(const bool state)
-  {
-    if (state) {
-      if (!active()) {
-        right = true;
-      }
-    } else {
-      if (isRunning()) {
-        left = true;
-        right = false;
-      }
-    }
-  }
-};
-
 /// \brief State data for spring commands and feedback from sensors for SCRecord message in ROS2
 struct SpringState
 {
@@ -80,8 +36,8 @@ struct SpringState
   int16_t status{0};  // TODO(andermi) status bit field
 
   // Commands
-  CommandTriState valve_command;
-  CommandTriState pump_command;
+  buoy_utils::CommandTriState valve_command;
+  buoy_utils::CommandTriState pump_command;
 
   bool operator==(const SpringState & that) const
   {

--- a/buoy_gazebo/src/PolytropicPneumaticSpring/SpringState.hpp
+++ b/buoy_gazebo/src/PolytropicPneumaticSpring/SpringState.hpp
@@ -36,8 +36,8 @@ struct SpringState
   int16_t status{0};  // TODO(andermi) status bit field
 
   // Commands
-  buoy_utils::CommandTriState valve_command;
-  buoy_utils::CommandTriState pump_command;
+  buoy_utils::CommandTriState<> valve_command;
+  buoy_utils::CommandTriState<> pump_command;
 
   bool operator==(const SpringState & that) const
   {

--- a/buoy_gazebo/src/buoy_utils/CMakeLists.txt
+++ b/buoy_gazebo/src/buoy_utils/CMakeLists.txt
@@ -2,9 +2,9 @@ add_library(StopwatchSimTime
   SHARED
     StopwatchSimTime.cpp
 )
-
 ament_target_dependencies(StopwatchSimTime PUBLIC rclcpp)
 
 install(
-  TARGETS StopwatchSimTime
+  TARGETS
+    StopwatchSimTime
   DESTINATION lib)

--- a/buoy_gazebo/src/buoy_utils/CommandTriState.hpp
+++ b/buoy_gazebo/src/buoy_utils/CommandTriState.hpp
@@ -1,0 +1,68 @@
+// Copyright 2022 Open Source Robotics Foundation, Inc. and Monterey Bay Aquarium Research Institute
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef BUOY_UTILS__COMMANDTRISTATE_HPP_
+#define BUOY_UTILS__COMMANDTRISTATE_HPP_
+
+
+namespace buoy_utils
+{
+/// \brief Command state variable that tracks if command is running, finished, or was ever active
+struct CommandTriState
+{
+  bool left{false};
+  bool right{false};
+
+  bool isRunning() const  // rising edge
+  {
+    return !left && right;
+  }
+
+  bool isFinished() const  // falling edge
+  {
+    return left && !right;
+  }
+
+  bool active() const  // running or finished
+  {
+    return left || right;
+  }
+
+  operator bool() const
+  {
+    return isRunning();
+  }
+
+  void reset()
+  {
+    left = right = false;  // no command activity
+  }
+
+  void operator=(const bool state)
+  {
+    if (state) {
+      if (!active()) {
+        right = true;
+      }
+    } else {
+      if (isRunning()) {
+        left = true;
+        right = false;
+      }
+    }
+  }
+};
+}  // namespace buoy_utils
+
+#endif  // BUOY_UTILS__COMMANDTRISTATE_HPP_

--- a/buoy_gazebo/src/buoy_utils/CommandTriState.hpp
+++ b/buoy_gazebo/src/buoy_utils/CommandTriState.hpp
@@ -15,7 +15,6 @@
 #ifndef BUOY_UTILS__COMMANDTRISTATE_HPP_
 #define BUOY_UTILS__COMMANDTRISTATE_HPP_
 
-#include <iostream>
 
 namespace buoy_utils
 {

--- a/buoy_gazebo/src/buoy_utils/CommandTriState.hpp
+++ b/buoy_gazebo/src/buoy_utils/CommandTriState.hpp
@@ -19,10 +19,12 @@
 namespace buoy_utils
 {
 /// \brief Command state variable that tracks if command is running, finished, or was ever active
-struct CommandTriState
+template<typename T = double>
+class CommandTriState
 {
-  bool left{false};
-  bool right{false};
+public:
+  typedef T valuetype;
+  valuetype value;
 
   bool isRunning() const  // rising edge
   {
@@ -62,7 +64,23 @@ struct CommandTriState
       }
     }
   }
+
+  void operator=(const valuetype & command)
+  {
+    value = command;
+    *this = true;
+  }
+  
+  operator const valuetype & () const
+  {
+    return value;
+  }
+
+private:
+  bool left{false};
+  bool right{false};
 };
+
 }  // namespace buoy_utils
 
 #endif  // BUOY_UTILS__COMMANDTRISTATE_HPP_

--- a/buoy_gazebo/src/buoy_utils/CommandTriState.hpp
+++ b/buoy_gazebo/src/buoy_utils/CommandTriState.hpp
@@ -15,6 +15,7 @@
 #ifndef BUOY_UTILS__COMMANDTRISTATE_HPP_
 #define BUOY_UTILS__COMMANDTRISTATE_HPP_
 
+#include <iostream>
 
 namespace buoy_utils
 {
@@ -24,21 +25,20 @@ class CommandTriState
 {
 public:
   typedef T valuetype;
-  valuetype value;
 
   bool isRunning() const  // rising edge
   {
-    return !left && right;
+    return !left_ && right_;
   }
 
   bool isFinished() const  // falling edge
   {
-    return left && !right;
+    return left_ && !right_;
   }
 
   bool active() const  // running or finished
   {
-    return left || right;
+    return left_ || right_;
   }
 
   operator bool() const
@@ -48,37 +48,38 @@ public:
 
   void reset()
   {
-    left = right = false;  // no command activity
+    left_ = right_ = false;  // no command activity
   }
 
   void operator=(const bool state)
   {
     if (state) {
       if (!active()) {
-        right = true;
+        right_ = true;
       }
     } else {
       if (isRunning()) {
-        left = true;
-        right = false;
+        left_ = true;
+        right_ = false;
       }
     }
   }
 
   void operator=(const valuetype & command)
   {
-    value = command;
+    value_ = command;
     *this = true;
   }
-  
-  operator const valuetype & () const
+
+  const valuetype & value() const
   {
-    return value;
+    return value_;
   }
 
 private:
-  bool left{false};
-  bool right{false};
+  bool left_{false};
+  bool right_{false};
+  valuetype value_;
 };
 
 }  // namespace buoy_utils

--- a/buoy_gazebo/src/controllers/PowerController/CMakeLists.txt
+++ b/buoy_gazebo/src/controllers/PowerController/CMakeLists.txt
@@ -1,0 +1,9 @@
+gz_add_plugin(PowerController
+  SOURCES
+    PowerController.cpp
+  INCLUDE_DIRS
+    ../..
+  PUBLIC_LINK_LIBS
+    StopwatchSimTime
+  ROS
+)

--- a/buoy_gazebo/src/controllers/PowerController/PowerController.cpp
+++ b/buoy_gazebo/src/controllers/PowerController/PowerController.cpp
@@ -337,17 +337,19 @@ struct PowerControllerPrivate
             services_->torque_command_duration_.seconds() << "s)");
 
         services_->torque_command_watch_.Start(true);
-      // stop overriding winding current (torque)
-      } else if (services_->torque_command_watch_.ElapsedRunTime() >=
-        services_->torque_command_duration_)
-      {
-        services_->torque_command_watch_.Stop();
-        state.torque_command = false;
+        // stop overriding winding current (torque)
+      } else {
+        if (services_->torque_command_watch_.ElapsedRunTime() >=
+          services_->torque_command_duration_)
+        {
+          services_->torque_command_watch_.Stop();
+          state.torque_command = false;
 
-        RCLCPP_INFO_STREAM(
-          ros_->node_->get_logger(),
-          "Stopped overriding Winding Current (Torque) after (" <<
-            services_->torque_command_watch_.ElapsedRunTime().seconds() << "s)");
+          RCLCPP_INFO_STREAM(
+            ros_->node_->get_logger(),
+            "Stopped overriding Winding Current (Torque) after (" <<
+              services_->torque_command_watch_.ElapsedRunTime().seconds() << "s)");
+        }
       }
     }
 
@@ -360,19 +362,21 @@ struct PowerControllerPrivate
             services_->scale_command_duration_.seconds() << "s)");
 
         services_->scale_command_watch_.Start(true);
-      // stop overriding scale factor
-      } else if (services_->scale_command_watch_.ElapsedRunTime() >=
-        services_->scale_command_duration_)
-      {
-        services_->scale_command_watch_.Stop();
-        state.scale_command = false;
+        // stop overriding scale factor
+      } else {
+        if (services_->scale_command_watch_.ElapsedRunTime() >=
+          services_->scale_command_duration_)
+        {
+          services_->scale_command_watch_.Stop();
+          state.scale_command = false;
 
-        RCLCPP_INFO_STREAM(
-          ros_->node_->get_logger(),
-          "Stopped overriding Scale Factor after (" <<
-            services_->scale_command_watch_.ElapsedRunTime().seconds() << "s)");
+          RCLCPP_INFO_STREAM(
+            ros_->node_->get_logger(),
+            "Stopped overriding Scale Factor after (" <<
+              services_->scale_command_watch_.ElapsedRunTime().seconds() << "s)");
+        }
       }
-    } 
+    }
   }
 
   void manageCommandState(ElectroHydraulicState & state)
@@ -404,7 +408,7 @@ struct PowerControllerPrivate
 
           RCLCPP_INFO_STREAM(
             ros_->node_->get_logger(),
-           "Continue Override Winding Current (Torque) (" <<
+            "Continue Override Winding Current (Torque) (" <<
               services_->torque_command_duration_.seconds() << "s)");
         } else {
           state.torque_command = services_->wind_curr_;
@@ -426,7 +430,7 @@ struct PowerControllerPrivate
 
           RCLCPP_INFO_STREAM(
             ros_->node_->get_logger(),
-           "Continue Override Scale Factor (" <<
+            "Continue Override Scale Factor (" <<
               services_->scale_command_duration_.seconds() << "s)");
         } else {
           state.scale_command = services_->scale_;

--- a/buoy_gazebo/src/controllers/PowerController/PowerController.cpp
+++ b/buoy_gazebo/src/controllers/PowerController/PowerController.cpp
@@ -478,7 +478,8 @@ struct PowerControllerPrivate
     std::atomic<bool> & new_command,
     const double & command_value,
     buoy_utils::StopwatchSimTime & watch,
-    rclcpp::Duration & duration)
+    rclcpp::Duration & duration,
+    const rclcpp::Duration & timeout)
   {
     if (command.isFinished()) {
       std::unique_lock lock(services_->command_mutex_);
@@ -493,7 +494,7 @@ struct PowerControllerPrivate
       if (services_command) {
         if (command) {
           command = command_value;
-          duration = PowerControllerServices::TORQUE_COMMAND_TIMEOUT + watch.ElapsedRunTime();
+          duration = timeout + watch.ElapsedRunTime();
 
           RCLCPP_INFO_STREAM(
             ros_->node_->get_logger(),
@@ -518,7 +519,8 @@ struct PowerControllerPrivate
       services_->new_torque_command_,
       services_->wind_curr_,
       services_->torque_command_watch_,
-      services_->torque_command_duration_);
+      services_->torque_command_duration_,
+      PowerControllerServices::TORQUE_COMMAND_TIMEOUT);
 
     manageCommandState(
       "Scale Factor",
@@ -527,7 +529,8 @@ struct PowerControllerPrivate
       services_->new_scale_command_,
       services_->scale_,
       services_->scale_command_watch_,
-      services_->scale_command_duration_);
+      services_->scale_command_duration_,
+      PowerControllerServices::SCALE_COMMAND_TIMEOUT);
 
     manageCommandState(
       "Retract Factor",
@@ -536,7 +539,8 @@ struct PowerControllerPrivate
       services_->new_retract_command_,
       services_->retract_,
       services_->retract_command_watch_,
-      services_->retract_command_duration_);
+      services_->retract_command_duration_,
+      PowerControllerServices::RETRACT_COMMAND_TIMEOUT);
 
     manageCommandState(
       "Bias Current",
@@ -545,7 +549,8 @@ struct PowerControllerPrivate
       services_->new_bias_curr_command_,
       services_->bias_curr_,
       services_->bias_curr_command_watch_,
-      services_->bias_curr_command_duration_);
+      services_->bias_curr_command_duration_,
+      PowerControllerServices::BIAS_CURR_COMMAND_TIMEOUT);
   }
 };
 

--- a/buoy_gazebo/src/controllers/PowerController/PowerController.cpp
+++ b/buoy_gazebo/src/controllers/PowerController/PowerController.cpp
@@ -1,0 +1,610 @@
+// Copyright 2022 Open Source Robotics Foundation, Inc. and Monterey Bay Aquarium Research Institute
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "SpringController.hpp"
+
+#include <ignition/gazebo/Model.hh>
+#include <ignition/gazebo/Util.hh>
+#include <ignition/gazebo/components/Name.hh>
+#include <ignition/common/Profiler.hh>
+#include <ignition/plugin/Register.hh>
+#include <ignition/msgs/wrench.pb.h>
+#include <ignition/transport/Node.hh>
+
+#include <rclcpp/rclcpp.hpp>
+#include <rcl_interfaces/msg/parameter_descriptor.hpp>
+
+#include <buoy_msgs/msg/sc_record.hpp>
+#include <buoy_msgs/srv/valve_command.hpp>
+#include <buoy_msgs/srv/pump_command.hpp>
+
+#include <algorithm>
+#include <chrono>
+#include <limits>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "buoy_utils/StopwatchSimTime.hpp"
+#include "PolytropicPneumaticSpring/SpringState.hpp"
+
+
+using namespace std::chrono_literals;
+
+namespace buoy_gazebo
+{
+struct SpringControllerROS2
+{
+  rclcpp::Node::SharedPtr node_{nullptr};
+  rclcpp::executors::MultiThreadedExecutor::SharedPtr executor_{nullptr};
+  rclcpp::Node::OnSetParametersCallbackHandle::SharedPtr parameter_handler_{nullptr};
+  bool use_sim_time_{true};
+
+  rclcpp::Publisher<buoy_msgs::msg::SCRecord>::SharedPtr sc_pub_{nullptr};
+  std::unique_ptr<rclcpp::Rate> pub_rate_{nullptr};
+  buoy_msgs::msg::SCRecord sc_record_;
+  double pub_rate_hz_{10.0};
+};
+
+struct SpringControllerServices
+{
+  rclcpp::Service<buoy_msgs::srv::ValveCommand>::SharedPtr valve_command_service_{nullptr};
+  std::function<void(std::shared_ptr<buoy_msgs::srv::ValveCommand::Request>,
+    std::shared_ptr<buoy_msgs::srv::ValveCommand::Response>)> valve_command_handler_;
+
+  rclcpp::Service<buoy_msgs::srv::PumpCommand>::SharedPtr pump_command_service_{nullptr};
+  std::function<void(std::shared_ptr<buoy_msgs::srv::PumpCommand::Request>,
+    std::shared_ptr<buoy_msgs::srv::PumpCommand::Response>)> pump_command_handler_;
+
+  buoy_utils::StopwatchSimTime command_watch_;
+  rclcpp::Duration command_duration_{0, 0U};
+
+  std::atomic<bool> valve_command_{false}, pump_command_{false};
+  std::atomic<bool> has_new_command_{false};
+
+  std::mutex command_mutex_;
+};
+
+struct SpringControllerPrivate
+{
+  ignition::gazebo::Entity entity_{ignition::gazebo::kNullEntity};
+  ignition::gazebo::Entity jointEntity_{ignition::gazebo::kNullEntity};
+  ignition::transport::Node node_;
+  std::function<void(const ignition::msgs::Wrench &)> ft_cb_;
+  std::chrono::steady_clock::duration current_time_;
+
+  std::mutex data_mutex_, next_access_mutex_, low_prio_mutex_;
+  std::atomic<bool> spring_data_valid_{false}, load_cell_data_valid_{false};
+
+  std::thread thread_executor_spin_, thread_publish_;
+  std::atomic<bool> stop_{false}, paused_{true};
+
+  int16_t seq_num{0};
+
+  std::unique_ptr<SpringControllerROS2> ros_;
+  std::unique_ptr<SpringControllerServices> services_;
+
+  bool data_valid() const
+  {
+    return spring_data_valid_ && load_cell_data_valid_;
+  }
+
+  void ros2_setup(const std::string & node_name, const std::string & ns)
+  {
+    if (!rclcpp::ok()) {
+      rclcpp::init(0, nullptr);
+    }
+
+    ros_->node_ = rclcpp::Node::make_shared(node_name, ns);
+
+    ros_->node_->set_parameter(
+      rclcpp::Parameter(
+        "use_sim_time",
+        ros_->use_sim_time_));
+
+    rcl_interfaces::msg::ParameterDescriptor descriptor;
+    rcl_interfaces::msg::FloatingPointRange range;
+    range.set__from_value(10.0F).set__to_value(50.0F).set__step(1.0F);
+    descriptor.floating_point_range = {range};
+    ros_->node_->declare_parameter("publish_rate", ros_->pub_rate_hz_, descriptor);
+
+    ros_->parameter_handler_ = ros_->node_->add_on_set_parameters_callback(
+      [this](const std::vector<rclcpp::Parameter> & parameters)
+      {
+        rcl_interfaces::msg::SetParametersResult result;
+        result.successful = true;
+        for (const auto & parameter : parameters) {
+          if (
+            parameter.get_name() == "publish_rate" &&
+            parameter.get_type() == rclcpp::PARAMETER_DOUBLE)
+          {
+            double rate_hz = parameter.as_double();
+            RCLCPP_INFO_STREAM(
+              ros_->node_->get_logger(),
+              "[ROS 2 Spring Control] setting publish_rate: " << rate_hz);
+
+            if (rate_hz < 10.0 || rate_hz > 50.0) {
+              RCLCPP_WARN_STREAM(
+                ros_->node_->get_logger(),
+                "[ROS 2 Spring Control] publish_rate out of bounds -- clipped between [10,50]");
+            }
+
+            ros_->pub_rate_hz_ = std::min(std::max(rate_hz, 10.0), 50.0);
+
+            // low prio data access
+            std::unique_lock low(low_prio_mutex_);
+            std::unique_lock next(next_access_mutex_);
+            std::unique_lock data(data_mutex_);
+            next.unlock();
+            ros_->pub_rate_ = std::make_unique<rclcpp::Rate>(ros_->pub_rate_hz_);
+            data.unlock();
+          }
+        }
+        return result;
+      });
+
+    ros_->executor_ = std::make_shared<rclcpp::executors::MultiThreadedExecutor>();
+    ros_->executor_->add_node(ros_->node_);
+    stop_ = false;
+
+    auto spin = [this]()
+      {
+        while (rclcpp::ok() && !stop_) {
+          ros_->executor_->spin_once();
+        }
+      };
+    thread_executor_spin_ = std::thread(spin);
+  }
+
+  void setup_services()
+  {
+    services_->command_watch_.SetClock(ros_->node_->get_clock());
+
+    // ValveCommand
+    services_->valve_command_handler_ =
+      [this](const std::shared_ptr<buoy_msgs::srv::ValveCommand::Request> request,
+        std::shared_ptr<buoy_msgs::srv::ValveCommand::Response> response)
+      {
+        RCLCPP_INFO_STREAM(
+          ros_->node_->get_logger(),
+          "[ROS 2 Spring Control] ValveCommand Received (" << request->duration_sec << "s)");
+
+        std::unique_lock lock(services_->command_mutex_);
+        // if already running pump, don't allow valve
+        // unless for some reason we need to turn valve off (shouldn't get in that state)
+        if (services_->pump_command_) {
+          if (request->duration_sec != request->OFF) {
+            response->result.value = response->result.BUSY;
+
+            RCLCPP_ERROR_STREAM(
+              ros_->node_->get_logger(),
+              "[ROS 2 Spring Control] ValveCommand cannot process" <<
+                " while pump command is running...");
+
+            return;
+          }
+        }
+
+        if (request->duration_sec == request->OFF) {
+          services_->command_duration_ = rclcpp::Duration(0, 0U);
+          services_->valve_command_ = false;
+          services_->has_new_command_ = true;
+        } else {
+          uint16_t duration_sec{request->duration_sec};
+          if (duration_sec > 20U) {
+            duration_sec = std::min(
+              std::max(duration_sec, static_cast<uint16_t>(1U)),
+              static_cast<uint16_t>(20U));
+
+            response->result.value = response->result.BAD_INPUT;
+
+            RCLCPP_WARN_STREAM(
+              ros_->node_->get_logger(),
+              "[ROS 2 Spring Control] ValveCommand out of bounds -- clipped to 20s");
+          }
+
+          services_->command_duration_ =
+            rclcpp::Duration::from_seconds(static_cast<double>(duration_sec));
+
+          services_->valve_command_ = true;
+          services_->has_new_command_ = true;
+        }
+      };
+    services_->valve_command_service_ =
+      ros_->node_->create_service<buoy_msgs::srv::ValveCommand>(
+      "valve_command",
+      services_->valve_command_handler_);
+
+    // PumpCommand
+    services_->pump_command_handler_ =
+      [this](const std::shared_ptr<buoy_msgs::srv::PumpCommand::Request> request,
+        std::shared_ptr<buoy_msgs::srv::PumpCommand::Response> response)
+      {
+        RCLCPP_INFO_STREAM(
+          ros_->node_->get_logger(),
+          "[ROS 2 Spring Control] PumpCommand Received (" << request->duration_sec << "s)");
+
+        std::unique_lock lock(services_->command_mutex_);
+        // if already running valve, don't allow pump
+        // unless for some reason we need to turn pump off (shouldn't get in that state)
+        if (services_->valve_command_) {
+          if (request->duration_sec != request->OFF) {
+            response->result.value = response->result.BUSY;
+
+            RCLCPP_ERROR_STREAM(
+              ros_->node_->get_logger(),
+              "[ROS 2 Spring Control] PumpCommand cannot process" <<
+                " while valve command is running...");
+
+            return;
+          }
+        }
+
+        if (request->duration_sec == request->OFF) {
+          services_->command_duration_ = rclcpp::Duration(0, 0U);
+          services_->pump_command_ = false;
+          services_->has_new_command_ = true;
+        } else {
+          uint16_t duration_sec{request->duration_sec};
+          if (duration_sec > 20U) {
+            duration_sec = std::min(
+              std::max(duration_sec, static_cast<uint16_t>(1U)),
+              static_cast<uint16_t>(20U));
+
+            response->result.value = response->result.BAD_INPUT;
+
+            RCLCPP_WARN_STREAM(
+              ros_->node_->get_logger(),
+              "[ROS 2 Spring Control] PumpCommand out of bounds -- clipped to 20s");
+          }
+
+          services_->command_duration_ =
+            rclcpp::Duration::from_seconds(static_cast<double>(duration_sec));
+
+          services_->pump_command_ = true;
+          services_->has_new_command_ = true;
+        }
+      };
+    services_->pump_command_service_ =
+      ros_->node_->create_service<buoy_msgs::srv::PumpCommand>(
+      "pump_command",
+      services_->pump_command_handler_);
+  }
+
+  void manageCommandTimer(SpringState & state)
+  {
+    static double init_x = 0.0;
+
+    // open valve
+    if (state.valve_command && !services_->command_watch_.Running()) {
+      RCLCPP_INFO_STREAM(
+        ros_->node_->get_logger(),
+        "Valve open (" <<
+          services_->command_duration_.seconds() << "s)");
+
+      services_->command_watch_.Start(true);
+      init_x = state.range_finder;
+
+      // turn pump on
+    } else if (state.pump_command.isRunning() && !services_->command_watch_.Running()) {
+      RCLCPP_INFO_STREAM(
+        ros_->node_->get_logger(),
+        "Pump on (" <<
+          services_->command_duration_.seconds() << "s)");
+
+      services_->command_watch_.Start(true);
+      init_x = state.range_finder;
+
+    } else {
+      // close valve
+      if (state.valve_command &&
+        services_->command_watch_.ElapsedRunTime() >= services_->command_duration_)
+      {
+        services_->command_watch_.Stop();
+        state.valve_command = false;
+
+        RCLCPP_INFO_STREAM(
+          ros_->node_->get_logger(),
+          "Valve closed after (" <<
+            services_->command_watch_.ElapsedRunTime().seconds() << "s)");
+
+        igndbg << "piston moved: " << (state.range_finder - init_x) /
+        (services_->command_watch_.ElapsedRunTime().nanoseconds() * IGN_NANO_TO_SEC) <<
+          " m/s" << std::endl;
+      }
+
+      // turn pump off
+      if (state.pump_command &&
+        services_->command_watch_.ElapsedRunTime() >= services_->command_duration_)
+      {
+        services_->command_watch_.Stop();
+        state.pump_command = false;
+
+        RCLCPP_INFO_STREAM(
+          ros_->node_->get_logger(),
+          "Pump off after (" <<
+            services_->command_watch_.ElapsedRunTime().seconds() << "s)");
+
+        igndbg << "piston moved: " << (state.range_finder - init_x) /
+        (services_->command_watch_.ElapsedRunTime().nanoseconds() * IGN_NANO_TO_SEC) <<
+          " m/s" << std::endl;
+      }
+    }
+  }
+
+  void manageCommandState(SpringState & state)
+  {
+    if (state.valve_command.isFinished()) {
+      std::unique_lock lock(services_->command_mutex_);
+      services_->valve_command_ = false;
+      services_->command_duration_ = rclcpp::Duration(0, 0U);
+      services_->command_watch_.Reset();
+      state.valve_command.reset();
+    }
+
+    if (state.pump_command.isFinished()) {
+      std::unique_lock lock(services_->command_mutex_);
+      services_->pump_command_ = false;
+      services_->command_duration_ = rclcpp::Duration(0, 0U);
+      services_->command_watch_.Reset();
+      state.pump_command.reset();
+    }
+
+    if (services_->has_new_command_) {
+      std::unique_lock lock(services_->command_mutex_);
+
+      if (state.valve_command || state.pump_command) {
+        state.valve_command = services_->valve_command_;
+        state.pump_command = services_->pump_command_;
+
+        services_->command_duration_ =
+          services_->command_duration_ +
+          services_->command_watch_.ElapsedRunTime();
+
+        if (state.valve_command) {
+          RCLCPP_INFO_STREAM(
+            ros_->node_->get_logger(),
+            "Valve open (" <<
+              services_->command_duration_.seconds() << "s)");
+
+        } else if (state.pump_command) {
+          RCLCPP_INFO_STREAM(
+            ros_->node_->get_logger(),
+            "Pump on (" <<
+              services_->command_duration_.seconds() << "s)");
+        }
+      } else {
+        state.valve_command = services_->valve_command_;
+        state.pump_command = services_->pump_command_;
+      }
+
+      services_->has_new_command_ = false;
+    }
+  }
+};
+
+//////////////////////////////////////////////////
+SpringController::SpringController()
+: dataPtr(std::make_unique<SpringControllerPrivate>())
+{
+  this->dataPtr->ros_ = std::make_unique<SpringControllerROS2>();
+  this->dataPtr->services_ = std::make_unique<SpringControllerServices>();
+}
+
+SpringController::~SpringController()
+{
+  // Stop ros2 threads
+  this->dataPtr->stop_ = true;
+  if (this->dataPtr->ros_->executor_) {
+    this->dataPtr->ros_->executor_->cancel();
+  }
+  this->dataPtr->thread_executor_spin_.join();
+  this->dataPtr->thread_publish_.join();
+}
+
+void SpringController::Configure(
+  const ignition::gazebo::Entity & _entity,
+  const std::shared_ptr<const sdf::Element> & _sdf,
+  ignition::gazebo::EntityComponentManager & _ecm,
+  ignition::gazebo::EventManager &)
+{
+  // Make sure the controller is attached to a valid model
+  auto model = ignition::gazebo::Model(_entity);
+  if (!model.Valid(_ecm)) {
+    ignerr << "[ROS 2 Spring Control] Failed to initialize because [" <<
+      model.Name(_ecm) << "] is not a model." << std::endl <<
+      "Please make sure that ROS 2 Spring Control is attached to a valid model." << std::endl;
+    return;
+  }
+
+  this->dataPtr->entity_ = _entity;
+
+  // Get params from SDF
+  auto jointName = _sdf->Get<std::string>("JointName");
+  if (jointName.empty()) {
+    ignerr << "SpringController found an empty JointName parameter. " <<
+      "Failed to initialize.";
+    return;
+  }
+
+  this->dataPtr->jointEntity_ = model.JointByName(_ecm, jointName);
+  if (this->dataPtr->jointEntity_ == ignition::gazebo::kNullEntity) {
+    ignerr << "Joint with name[" << jointName << "] not found. " <<
+      "The SpringController may not influence this joint.\n";
+    return;
+  }
+
+  // controller scoped name
+  std::string scoped_name = ignition::gazebo::scopedName(_entity, _ecm, "/", false);
+
+  // ROS node
+  std::string ns = _sdf->Get<std::string>("namespace", scoped_name).first;
+  if (ns.empty() || ns[0] != '/') {
+    ns = '/' + ns;
+  }
+  std::string node_name = _sdf->Get<std::string>("node_name", "spring_controller").first;
+
+  this->dataPtr->ros2_setup(node_name, ns);
+
+  RCLCPP_INFO_STREAM(
+    this->dataPtr->ros_->node_->get_logger(),
+    "[ROS 2 Spring Control] Setting up controller for [" << model.Name(_ecm) << "]");
+
+  // Force Torque Sensor
+  this->dataPtr->ft_cb_ = [this](const ignition::msgs::Wrench & _msg)
+    {
+      // low prio data access
+      std::unique_lock low(this->dataPtr->low_prio_mutex_);
+      std::unique_lock next(this->dataPtr->next_access_mutex_);
+      std::unique_lock data(this->dataPtr->data_mutex_);
+      next.unlock();
+      this->dataPtr->ros_->sc_record_.load_cell = _msg.force().z();
+      this->dataPtr->load_cell_data_valid_ = true;
+      data.unlock();
+    };
+  if (!this->dataPtr->node_.Subscribe("/Universal_joint/force_torque", this->dataPtr->ft_cb_)) {
+    ignerr << "Error subscribing to topic [" << "/Universal_joint/force_torque" << "]" << std::endl;
+    return;
+  }
+
+  // Publisher
+  std::string topic = _sdf->Get<std::string>("topic", "sc_record").first;
+  this->dataPtr->ros_->sc_pub_ =
+    this->dataPtr->ros_->node_->create_publisher<buoy_msgs::msg::SCRecord>(topic, 10);
+
+  this->dataPtr->ros_->pub_rate_hz_ =
+    _sdf->Get<double>("publish_rate", this->dataPtr->ros_->pub_rate_hz_).first;
+
+  RCLCPP_INFO_STREAM(
+    this->dataPtr->ros_->node_->get_logger(),
+    "[ROS 2 Spring Control] Set publish_rate param from SDF: " <<
+      this->dataPtr->ros_->pub_rate_hz_);
+
+  this->dataPtr->ros_->node_->set_parameter(
+    rclcpp::Parameter(
+      "publish_rate",
+      this->dataPtr->ros_->pub_rate_hz_));
+
+  auto publish = [this]()
+    {
+      while (rclcpp::ok() && !this->dataPtr->stop_) {
+        if (this->dataPtr->ros_->sc_pub_->get_subscription_count() <= 0) {continue;}
+
+        // Only update and publish if not paused.
+        if (this->dataPtr->paused_) {continue;}
+
+        buoy_msgs::msg::SCRecord sc_record;
+        // high prio data access
+        std::unique_lock next(this->dataPtr->next_access_mutex_);
+        std::unique_lock data(this->dataPtr->data_mutex_);
+        next.unlock();
+
+        if (this->dataPtr->data_valid()) {
+          this->dataPtr->ros_->sc_record_.seq_num =
+            this->dataPtr->seq_num++ % std::numeric_limits<int16_t>::max();
+          sc_record = this->dataPtr->ros_->sc_record_;
+          data.unlock();
+
+          this->dataPtr->ros_->sc_pub_->publish(sc_record);
+        } else {
+          data.unlock();
+        }
+
+        this->dataPtr->ros_->pub_rate_->sleep();
+      }
+    };
+  this->dataPtr->thread_publish_ = std::thread(publish);
+
+  this->dataPtr->setup_services();
+}
+
+/////////////////////////////////////////////////////////////////////////////////////////////
+void SpringController::PreUpdate(
+  const ignition::gazebo::UpdateInfo & _info,
+  ignition::gazebo::EntityComponentManager & _ecm)
+{
+  IGN_PROFILE("SpringController::PreUpdate");
+
+  this->dataPtr->paused_ = _info.paused;
+  this->dataPtr->current_time_ = _info.simTime;
+
+  if (!_ecm.EntityHasComponentType(
+      this->dataPtr->jointEntity_,
+      buoy_gazebo::components::SpringState().TypeId()))
+  {
+    return;
+  }
+
+  auto spring_state_comp =
+    _ecm.Component<buoy_gazebo::components::SpringState>(this->dataPtr->jointEntity_);
+
+  this->dataPtr->manageCommandTimer(spring_state_comp->Data());
+  this->dataPtr->manageCommandState(spring_state_comp->Data());
+}
+
+/////////////////////////////////////////////////////////////////////////////////////////////
+void SpringController::PostUpdate(
+  const ignition::gazebo::UpdateInfo & _info,
+  const ignition::gazebo::EntityComponentManager & _ecm)
+{
+  IGN_PROFILE("SpringController::PostUpdate");
+
+  this->dataPtr->paused_ = _info.paused;
+  this->dataPtr->current_time_ = _info.simTime;
+
+  if (!_ecm.EntityHasComponentType(
+      this->dataPtr->jointEntity_,
+      buoy_gazebo::components::SpringState().TypeId()))
+  {
+    // Pneumatic Spring hasn't updated values yet
+    this->dataPtr->spring_data_valid_ = false;
+    return;
+  }
+
+  auto spring_state_comp =
+    _ecm.Component<buoy_gazebo::components::SpringState>(this->dataPtr->jointEntity_);
+
+  // low prio data access
+  std::unique_lock low(this->dataPtr->low_prio_mutex_);
+  std::unique_lock next(this->dataPtr->next_access_mutex_);
+  std::unique_lock data(this->dataPtr->data_mutex_);
+  next.unlock();
+
+  auto sec_nsec = ignition::math::durationToSecNsec(this->dataPtr->current_time_);
+
+  this->dataPtr->ros_->sc_record_.header.stamp.sec = sec_nsec.first;
+  this->dataPtr->ros_->sc_record_.header.stamp.nanosec = sec_nsec.second;
+  this->dataPtr->ros_->sc_record_.range_finder = spring_state_comp->Data().range_finder;
+  this->dataPtr->ros_->sc_record_.upper_psi = spring_state_comp->Data().upper_psi;
+  this->dataPtr->ros_->sc_record_.lower_psi = spring_state_comp->Data().lower_psi;
+
+  // Currently existing but unused fields by physical buoy -- the CTD sensor is not in service
+  // this->dataPtr->sc_record_.epoch = spring_state_comp->Data().epoch_;
+  // this->dataPtr->sc_record_.salinity = spring_state_comp->Data().salinity_;
+  // this->dataPtr->sc_record_.temperature = spring_state_comp->Data().temperature_;
+
+  // TODO(andermi) set the bits for this
+  this->dataPtr->ros_->sc_record_.status = spring_state_comp->Data().status;
+
+  this->dataPtr->spring_data_valid_ = true;
+  data.unlock();
+}
+}  // namespace buoy_gazebo
+
+IGNITION_ADD_PLUGIN(
+  buoy_gazebo::SpringController,
+  ignition::gazebo::System,
+  buoy_gazebo::SpringController::ISystemConfigure,
+  buoy_gazebo::SpringController::ISystemPreUpdate,
+  buoy_gazebo::SpringController::ISystemPostUpdate)

--- a/buoy_gazebo/src/controllers/PowerController/PowerController.hpp
+++ b/buoy_gazebo/src/controllers/PowerController/PowerController.hpp
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef CONTROLLERS__SPRINGCONTROLLER__SPRINGCONTROLLER_HPP_
-#define CONTROLLERS__SPRINGCONTROLLER__SPRINGCONTROLLER_HPP_
+#ifndef CONTROLLERS__POWERCONTROLLER__POWERCONTROLLER_HPP_
+#define CONTROLLERS__POWERCONTROLLER__POWERCONTROLLER_HPP_
 
 #include <ignition/gazebo/System.hh>
 #include <memory>
@@ -21,14 +21,18 @@
 namespace buoy_gazebo
 {
 // Forward declarations.
-struct SpringControllerPrivate;
+struct PowerControllerPrivate;
+
+/// \brief ROS2 Power Controller node for publishing PCRecord and accepting power commands
+/// Uses parameter to set publish rate (PCPackRate).
+/// Uses ros_ign_bridge and use_sim_time to get /clock from gazebo for command timing.
 
 /// SDF parameters:
 /// * `<namespace>`: Namespace for ROS node, defaults to scoped name
-/// * `<node_name>`: ROS2 node name, defaults to "spring_controller"
-/// * `<topic>`: ROS2 topic to publish to, defaults to "sc_record"
+/// * `<node_name>`: ROS2 node name, defaults to "power_controller"
+/// * `<topic>`: ROS2 topic to publish to, defaults to "pc_record"
 /// * `<publish_rate>`: ROS2 topic publish rate, defaults to 10Hz
-class SpringController
+class PowerController
   : public ignition::gazebo::System,
   public ignition::gazebo::ISystemConfigure,
   public ignition::gazebo::ISystemPreUpdate,
@@ -36,10 +40,10 @@ class SpringController
 {
 public:
   /// \brief Constructor
-  SpringController();
+  PowerController();
 
   /// \brief Destructor
-  ~SpringController() override;
+  ~PowerController() override;
 
   // Documentation inherited
   void Configure(
@@ -60,8 +64,8 @@ public:
 
 private:
   /// \brief Private data pointer.
-  std::unique_ptr<SpringControllerPrivate> dataPtr;
+  std::unique_ptr<PowerControllerPrivate> dataPtr;
 };
 }  // namespace buoy_gazebo
 
-#endif  // CONTROLLERS__SPRINGCONTROLLER__SPRINGCONTROLLER_HPP_
+#endif  // CONTROLLERS__POWERCONTROLLER__POWERCONTROLLER_HPP_

--- a/buoy_gazebo/src/controllers/PowerController/PowerController.hpp
+++ b/buoy_gazebo/src/controllers/PowerController/PowerController.hpp
@@ -1,0 +1,67 @@
+// Copyright 2022 Open Source Robotics Foundation, Inc. and Monterey Bay Aquarium Research Institute
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef CONTROLLERS__SPRINGCONTROLLER__SPRINGCONTROLLER_HPP_
+#define CONTROLLERS__SPRINGCONTROLLER__SPRINGCONTROLLER_HPP_
+
+#include <ignition/gazebo/System.hh>
+#include <memory>
+
+namespace buoy_gazebo
+{
+// Forward declarations.
+struct SpringControllerPrivate;
+
+/// SDF parameters:
+/// * `<namespace>`: Namespace for ROS node, defaults to scoped name
+/// * `<node_name>`: ROS2 node name, defaults to "spring_controller"
+/// * `<topic>`: ROS2 topic to publish to, defaults to "sc_record"
+/// * `<publish_rate>`: ROS2 topic publish rate, defaults to 10Hz
+class SpringController
+  : public ignition::gazebo::System,
+  public ignition::gazebo::ISystemConfigure,
+  public ignition::gazebo::ISystemPreUpdate,
+  public ignition::gazebo::ISystemPostUpdate
+{
+public:
+  /// \brief Constructor
+  SpringController();
+
+  /// \brief Destructor
+  ~SpringController() override;
+
+  // Documentation inherited
+  void Configure(
+    const ignition::gazebo::Entity & _entity,
+    const std::shared_ptr<const sdf::Element> & _sdf,
+    ignition::gazebo::EntityComponentManager & _ecm,
+    ignition::gazebo::EventManager & _eventMgr) override;
+
+  // Documentation inherited
+  void PreUpdate(
+    const ignition::gazebo::UpdateInfo & _info,
+    ignition::gazebo::EntityComponentManager & _ecm) override;
+
+  // Documentation inherited
+  void PostUpdate(
+    const ignition::gazebo::UpdateInfo & _info,
+    const ignition::gazebo::EntityComponentManager & _ecm) override;
+
+private:
+  /// \brief Private data pointer.
+  std::unique_ptr<SpringControllerPrivate> dataPtr;
+};
+}  // namespace buoy_gazebo
+
+#endif  // CONTROLLERS__SPRINGCONTROLLER__SPRINGCONTROLLER_HPP_

--- a/buoy_gazebo/src/controllers/SpringController/SpringController.cpp
+++ b/buoy_gazebo/src/controllers/SpringController/SpringController.cpp
@@ -290,10 +290,10 @@ struct SpringControllerPrivate
           ros_->node_->get_logger(),
           "Valve closed after (" << \
             services_->command_watch_.ElapsedRunTime().seconds() << "s)");
-        igndbg << "piston moved: " << \
-        (state.range_finder - init_x) / \
+        ignerr << "piston moved: " << \
+        (1.0/0.0254) * (state.range_finder - init_x) / \
         (services_->command_watch_.ElapsedRunTime().nanoseconds() * IGN_NANO_TO_SEC) << \
-          " m/s" << std::endl;
+          " in/s" << std::endl;
       }
       // turn pump off
       if (state.pump_command && \
@@ -305,10 +305,10 @@ struct SpringControllerPrivate
           ros_->node_->get_logger(),
           "Pump off after (" << \
             services_->command_watch_.ElapsedRunTime().seconds() << "s)");
-        igndbg << "piston moved: " << \
-        (state.range_finder - init_x) / \
-        (services_->command_watch_.ElapsedRunTime().nanoseconds() * IGN_NANO_TO_SEC) << \
-          " m/s" << std::endl;
+        ignerr << "piston moved: " << \
+        (1.0/0.0254) * (state.range_finder - init_x) / \
+        ((services_->command_watch_.ElapsedRunTime().nanoseconds() * IGN_NANO_TO_SEC) / 60.0) << \
+          " in/min" << std::endl;
       }
     }
   }

--- a/buoy_gazebo/src/controllers/SpringController/SpringController.cpp
+++ b/buoy_gazebo/src/controllers/SpringController/SpringController.cpp
@@ -539,18 +539,29 @@ void SpringController::PreUpdate(
   this->dataPtr->paused_ = _info.paused;
   this->dataPtr->current_time_ = _info.simTime;
 
-  if (!_ecm.EntityHasComponentType(
-      this->dataPtr->jointEntity_,
-      buoy_gazebo::components::SpringState().TypeId()))
-  {
+  if (_info.paused) {
     return;
   }
 
-  auto spring_state_comp =
-    _ecm.Component<buoy_gazebo::components::SpringState>(this->dataPtr->jointEntity_);
+  buoy_gazebo::SpringState spring_state;
+  if (_ecm.EntityHasComponentType(
+      this->dataPtr->jointEntity_,
+      buoy_gazebo::components::SpringState().TypeId()))
+  {
+    auto spring_state_comp =
+      _ecm.Component<buoy_gazebo::components::SpringState>(this->dataPtr->jointEntity_);
 
-  this->dataPtr->manageCommandTimer(spring_state_comp->Data());
-  this->dataPtr->manageCommandState(spring_state_comp->Data());
+    spring_state = buoy_gazebo::SpringState(spring_state_comp->Data());
+  } else {
+    return;
+  }
+
+  this->dataPtr->manageCommandTimer(spring_state);
+  this->dataPtr->manageCommandState(spring_state);
+
+  _ecm.SetComponentData<buoy_gazebo::components::SpringState>(
+    this->dataPtr->jointEntity_,
+    spring_state);
 }
 
 /////////////////////////////////////////////////////////////////////////////////////////////
@@ -562,6 +573,10 @@ void SpringController::PostUpdate(
 
   this->dataPtr->paused_ = _info.paused;
   this->dataPtr->current_time_ = _info.simTime;
+
+  if (_info.paused) {
+    return;
+  }
 
   if (!_ecm.EntityHasComponentType(
       this->dataPtr->jointEntity_,

--- a/buoy_gazebo/src/controllers/SpringController/SpringController.cpp
+++ b/buoy_gazebo/src/controllers/SpringController/SpringController.cpp
@@ -290,10 +290,9 @@ struct SpringControllerPrivate
           ros_->node_->get_logger(),
           "Valve closed after (" << \
             services_->command_watch_.ElapsedRunTime().seconds() << "s)");
-        ignerr << "piston moved: " << \
-        (1.0/0.0254) * (state.range_finder - init_x) / \
+        igndbg << "piston moved: " << (state.range_finder - init_x) /
         (services_->command_watch_.ElapsedRunTime().nanoseconds() * IGN_NANO_TO_SEC) << \
-          " in/s" << std::endl;
+          " m/s" << std::endl;
       }
       // turn pump off
       if (state.pump_command && \
@@ -305,10 +304,9 @@ struct SpringControllerPrivate
           ros_->node_->get_logger(),
           "Pump off after (" << \
             services_->command_watch_.ElapsedRunTime().seconds() << "s)");
-        ignerr << "piston moved: " << \
-        (1.0/0.0254) * (state.range_finder - init_x) / \
-        ((services_->command_watch_.ElapsedRunTime().nanoseconds() * IGN_NANO_TO_SEC) / 60.0) << \
-          " in/min" << std::endl;
+        igndbg << "piston moved: " << (state.range_finder - init_x) /
+        (services_->command_watch_.ElapsedRunTime().nanoseconds() * IGN_NANO_TO_SEC) << \
+          " m/s" << std::endl;
       }
     }
   }

--- a/buoy_gazebo/worlds/mbari_wec.sdf
+++ b/buoy_gazebo/worlds/mbari_wec.sdf
@@ -79,7 +79,7 @@
         <is_upper>true</is_upper>
         <!-- measure of valve opening cross-section and duration (meter-seconds) -->
         <valve_absement>49e-7</valve_absement>
-        <pump_absement>50e-8</pump_absement>
+        <pump_absement>20e-8</pump_absement>
         <pump_pressure>1.7e+6</pump_pressure>
         <stroke>2.03</stroke>
         <piston_area>0.0127</piston_area>
@@ -103,7 +103,7 @@
         <is_upper>false</is_upper>
         <!-- measure of valve opening cross-section and duration (meter-seconds) -->
         <valve_absement>49e-7</valve_absement>
-        <pump_absement>50e-8</pump_absement>
+        <pump_absement>20e-8</pump_absement>
         <pump_pressure>1.7e+6</pump_pressure>
         <stroke>2.03</stroke>
         <piston_area>0.0115</piston_area>

--- a/buoy_gazebo/worlds/mbari_wec.sdf
+++ b/buoy_gazebo/worlds/mbari_wec.sdf
@@ -79,7 +79,7 @@
         <is_upper>true</is_upper>
         <!-- measure of valve opening cross-section and duration (meter-seconds) -->
         <valve_absement>49e-7</valve_absement>
-        <pump_absement>40e-8</pump_absement>
+        <pump_absement>50e-8</pump_absement>
         <pump_pressure>1.7e+6</pump_pressure>
         <stroke>2.03</stroke>
         <piston_area>0.0127</piston_area>
@@ -103,7 +103,7 @@
         <is_upper>false</is_upper>
         <!-- measure of valve opening cross-section and duration (meter-seconds) -->
         <valve_absement>49e-7</valve_absement>
-        <pump_absement>40e-8</pump_absement>
+        <pump_absement>50e-8</pump_absement>
         <pump_pressure>1.7e+6</pump_pressure>
         <stroke>2.03</stroke>
         <piston_area>0.0115</piston_area>

--- a/buoy_gazebo/worlds/mbari_wec.sdf
+++ b/buoy_gazebo/worlds/mbari_wec.sdf
@@ -63,6 +63,14 @@
         <topic>sc_record</topic>
         <publish_rate>31</publish_rate>
       </plugin>
+
+      <plugin filename="PowerController" name="buoy_gazebo::PowerController">
+        <JointName>HydraulicRam</JointName>
+        <namespace>/</namespace>
+        <node_name>power_controller</node_name>
+        <topic>pc_record</topic>
+        <publish_rate>23</publish_rate>
+      </plugin>
       
       <plugin filename="XBowAHRS" name="buoy_gazebo::XBowAHRS">
         <namespace>/</namespace>


### PR DESCRIPTION
Addresses #30 #45

Power Controller should accept ROS2 commands via services and communicate commands to ElectroHydraulicPTO plugin.

Feedback -- Todo:
- [x] Add `PCRecord` data to ECM from ElectroHydraulicPTO
- [x] Publish `PCRecord` data from ECM in PowerController ROS2 System Plugin
~~- [ ] Implement PowerController Status bit-field~~

Command -- Todo:
- [x] `publish_rate` via parameter
- [x] `PCWindCurrCommand` via `/pc_wind_curr_command`
- [x] `PCScaleCommand` via `/pc_scale_command`
- [x] `PCRetractCommand` via `/pc_retract_command`
- [x] `PCBiasCurrCommand` via `/pc_bias_curr_command`
~~- [ ] `PCBattSwitchCommand` via `/pc_batt_switch_command`~~
~~- [ ] `PCChargeCurrLimCommand` via `/pc_charge_curr_lim_command`~~
~~- [ ] `PCDrawCurrLimCommand` via `/pc_draw_curr_lim_command`~~
~~- [ ] `PCStdDevTargCommand` via `/pc_std_dev_targ_command`~~
~~- [ ] `PCVTargMaxCommand` via `/pc_v_targ_max_command`~~
~~- [ ] `GainCommand` via `/gain_command`~~
~~- [x] `PCPackRateCommand` via `/pc_pack_rate_command`~~