### PR TITLE
Add odometry publisher

### DIFF
--- a/buoy_gazebo/worlds/buoy_playground.sdf
+++ b/buoy_gazebo/worlds/buoy_playground.sdf
@@ -239,6 +239,15 @@
         <use_pose_vector_msg>true</use_pose_vector_msg>
         <static_publisher>true</static_publisher>
       </plugin>
+
+      <plugin
+        filename="ignition-gazebo-odometry-publisher-system"
+        name="ignition::gazebo::systems::OdometryPublisher">
+        <dimensions>3</dimensions>
+        <odom_frame>MBARI_WEC/odom</odom_frame>
+        <robot_base_frame>MBARI_WEC/Buoy</robot_base_frame>
+      </plugin>
+
     </model>
   </world>
 </sdf>

--- a/buoy_gazebo/worlds/mbari_wec.sdf
+++ b/buoy_gazebo/worlds/mbari_wec.sdf
@@ -129,6 +129,13 @@
         <use_pose_vector_msg>true</use_pose_vector_msg>
         <static_publisher>true</static_publisher>
       </plugin>
+
+      <plugin
+        filename="ignition-gazebo-odometry-publisher-system"
+        name="ignition::gazebo::systems::OdometryPublisher">
+        <dimensions>3</dimensions>
+      </plugin>
+
     </model>
   </world>
 </sdf>

--- a/buoy_gazebo/worlds/mbari_wec.sdf
+++ b/buoy_gazebo/worlds/mbari_wec.sdf
@@ -134,6 +134,8 @@
         filename="ignition-gazebo-odometry-publisher-system"
         name="ignition::gazebo::systems::OdometryPublisher">
         <dimensions>3</dimensions>
+        <odom_frame>MBARI_WEC/odom</odom_frame>
+        <robot_base_frame>MBARI_WEC/Buoy</robot_base_frame>
       </plugin>
 
     </model>


### PR DESCRIPTION
* Requires https://github.com/gazebosim/gz-sim/pull/1534

Use the odometry publisher to get the transform from the buoy to the world.


![buoy_rviz](https://user-images.githubusercontent.com/5751272/173466022-473db726-fa52-46c7-b043-e36788566bda.gif)



