### PR TITLE
Publish tf_static with transient_local durability

### DIFF
--- a/buoy_gazebo/launch/mbari_wec.launch.py
+++ b/buoy_gazebo/launch/mbari_wec.launch.py
@@ -84,15 +84,8 @@ def generate_launch_description():
             (link_pose_gz_topic, '/tf'),
             (link_pose_gz_topic + '_static', '/tf_static'),
         ],
+        parameters=[{'qos_overrides./tf_static.publisher.durability' : 'transient_local'}],
         output='screen'
-    )
-
-    # Mapping initial frame
-    tf_buoy = Node(
-        package='tf2_ros',
-        executable='static_transform_publisher',
-        arguments=['0', '0', '0', '0', '0', '0', 'MBARI_WEC/Buoy', 'MBARI_WEC'],
-        condition=IfCondition(LaunchConfiguration('rviz')),
     )
 
     # Get the parser plugin convert sdf to urdf using robot_description topic
@@ -124,7 +117,6 @@ def generate_launch_description():
         rviz_launch_arg,
         gazebo,
         bridge,
-        tf_buoy,
         robot_state_publisher,
         rviz
     ])

--- a/buoy_gazebo/package.xml
+++ b/buoy_gazebo/package.xml
@@ -15,6 +15,7 @@
   <depend>buoy_msgs</depend>
   <depend>ignition-gazebo6</depend>
   <depend>robot_state_publisher</depend>
+  <depend>ros_ign_bridge</depend>
   <depend>ros_ign_gazebo</depend>
   <depend>rviz2</depend>
   <depend>sdformat_urdf</depend>

--- a/buoy_gazebo/worlds/buoy_playground.sdf
+++ b/buoy_gazebo/worlds/buoy_playground.sdf
@@ -238,6 +238,7 @@
         <publish_link_pose>true</publish_link_pose>
         <use_pose_vector_msg>true</use_pose_vector_msg>
         <static_publisher>true</static_publisher>
+        <static_update_frequency>1</static_update_frequency>
       </plugin>
 
       <plugin
@@ -245,7 +246,7 @@
         name="ignition::gazebo::systems::OdometryPublisher">
         <dimensions>3</dimensions>
         <odom_frame>MBARI_WEC/odom</odom_frame>
-        <robot_base_frame>MBARI_WEC/Buoy</robot_base_frame>
+        <robot_base_frame>MBARI_WEC</robot_base_frame>
       </plugin>
 
     </model>

--- a/buoy_gazebo/worlds/mbari_wec.sdf
+++ b/buoy_gazebo/worlds/mbari_wec.sdf
@@ -132,6 +132,7 @@
         <publish_link_pose>true</publish_link_pose>
         <use_pose_vector_msg>true</use_pose_vector_msg>
         <static_publisher>true</static_publisher>
+        <static_update_frequency>1</static_update_frequency>
       </plugin>
 
       <plugin
@@ -139,7 +140,7 @@
         name="ignition::gazebo::systems::OdometryPublisher">
         <dimensions>3</dimensions>
         <odom_frame>MBARI_WEC/odom</odom_frame>
-        <robot_base_frame>MBARI_WEC/Buoy</robot_base_frame>
+        <robot_base_frame>MBARI_WEC</robot_base_frame>
       </plugin>
 
     </model>


### PR DESCRIPTION
* Targets #50 
* Requires https://github.com/gazebosim/ros_gz/pull/259

## Tracking down the issue

@quarkytale , I figured out what the `tf_static` issue was. It turns out it's a QoS mismatch. I found out because when I tried to view TF with

```
ros2 run tf2_tools view_frames
```

I'd see a message saying 

```
[WARN] [1655778779.765880584] [view_frames]: New publisher discovered on topic '/tf_static', offering incompatible QoS. No messages will be received from it. Last incompatible policy: DURABILITY
```

Then with the following, I saw that the subscriber was expecting `TRANSIENT_LOCAL` durability (i.e. latched message)

```
ros2 topic info /tf_static -v
```

## Changes

* Override the durability for the `tf_static` topic using a parameter on the launch file. That requires #259 to be merged upstream.
* Remove the static transform that was filling the gap so far
* Depend on `ros_ign_bridge` - that helps when building in a colcon workspace, and should also help CI / releasing
* Reduce the static publish frequency to 1 Hz (it defaults to 50Hz), because that doesn't change anyway
* Use the model frame `MBARI_WEC` instead of the canonical link frame `MBARI_WEC/Buoy` for odom. That's the proper frame to use, because in the future we may add an offset between these 2.