### PR TITLE
Removing colcon warning

### DIFF
--- a/.github/workflows/build-and-test.sh
+++ b/.github/workflows/build-and-test.sh
@@ -33,6 +33,7 @@ rosdep install --from-paths ./ -i -y -r --rosdistro $ROS_DISTRO
 source /opt/ros/$ROS_DISTRO/setup.bash
 cd $COLCON_WS
 colcon build --packages-up-to buoy_tests --event-handlers console_direct+
+source $COLCON_WS/install/setup.bash
 
 # Test all buoy packages
 colcon test --packages-select-regex=buoy --event-handlers console_direct+

--- a/buoy_tests/CMakeLists.txt
+++ b/buoy_tests/CMakeLists.txt
@@ -1,39 +1,38 @@
 cmake_minimum_required(VERSION 3.5)
 project(buoy_tests)
 
-if(NOT BUILD_TESTING)
-  return()
-endif()
-
 find_package(ament_cmake REQUIRED)
 
-find_package(ignition-gazebo6 REQUIRED)
-set(GZ_SIM_VER ${ignition-gazebo6_VERSION_MAJOR})
+if(BUILD_TESTING)
+  find_package(ignition-gazebo6 REQUIRED)
+  set(GZ_SIM_VER ${ignition-gazebo6_VERSION_MAJOR})
 
-# Linters
-find_package(ament_lint_auto REQUIRED)
-ament_lint_auto_find_test_dependencies()
+  # Linters
+  find_package(ament_lint_auto REQUIRED)
+  ament_lint_auto_find_test_dependencies()
 
-# GTest
-find_package(ament_cmake_gtest REQUIRED)
-ament_find_gtest()
+  # GTest
+  find_package(ament_cmake_gtest REQUIRED)
+  ament_find_gtest()
 
-# Helper function to generate tests
-function(buoy_add_test TEST_NAME)
+  # Helper function to generate tests
+  function(buoy_add_test TEST_NAME)
 
-  ament_add_gtest(${TEST_NAME} tests/${TEST_NAME}.cpp)
-  target_link_libraries(${TEST_NAME}
-    ignition-gazebo${GZ_SIM_VER}::ignition-gazebo${GZ_SIM_VER}
-  )
-  include_directories(${CMAKE_CURRENT_BINARY_DIR})
-  install(
-    TARGETS ${TEST_NAME}
-    DESTINATION lib/${PROJECT_NAME}
-  )
+    ament_add_gtest(${TEST_NAME} tests/${TEST_NAME}.cpp)
+    target_link_libraries(${TEST_NAME}
+      ignition-gazebo${GZ_SIM_VER}::ignition-gazebo${GZ_SIM_VER}
+    )
+    include_directories(${CMAKE_CURRENT_BINARY_DIR})
+    install(
+      TARGETS ${TEST_NAME}
+      DESTINATION lib/${PROJECT_NAME}
+    )
 
-endfunction()
+  endfunction()
 
-# Add tests
-buoy_add_test(no_inputs)
+  # Add tests
+  buoy_add_test(no_inputs)
+
+endif()
 
 ament_package()


### PR DESCRIPTION
This should take care of the warning while building `buoy_tests` package.

```
[75.327s] WARNING:colcon.colcon_cmake.task.cmake.build:Could not run installation step for package 'buoy_tests' because it has no 'install' target
```

Modified the `BUILD_TESTING` flag logic. Ideally, `return()` should bring back control to the parent `CMakeLists.txt`, but here there is none which might be causing the issue.