### PR TITLE
Updating worlds after model reorg

### DIFF
--- a/buoy_description/CMakeLists.txt
+++ b/buoy_description/CMakeLists.txt
@@ -3,14 +3,18 @@ project(buoy_description)
 find_package(ament_cmake REQUIRED)
 
 # Model Generation
-set(BUOY_MODEL_PATH "/models/mbari_wec_base")
-file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}${BUOY_MODEL_PATH})
+set(BUOY_BASE_MODEL_PATH "/models/mbari_wec_base")
+file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}${BUOY_BASE_MODEL_PATH})
 add_custom_command(
   OUTPUT model_gen_cmd
   COMMAND empy3
-    ${CMAKE_CURRENT_SOURCE_DIR}${BUOY_MODEL_PATH}/model.sdf.em >
-    ${CMAKE_CURRENT_BINARY_DIR}${BUOY_MODEL_PATH}/model.sdf
+    ${CMAKE_CURRENT_SOURCE_DIR}${BUOY_BASE_MODEL_PATH}/model.sdf.em >
+    ${CMAKE_CURRENT_BINARY_DIR}${BUOY_BASE_MODEL_PATH}/model.sdf
 )
+set(BUOY_MODEL_PATH "/models/mbari_wec")
+file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}${BUOY_MODEL_PATH})
+set(BUOY_ROS_MODEL_PATH "/models/mbari_wec_ros")
+file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}${BUOY_ROS_MODEL_PATH})
 
 add_custom_target(model_gen_target ALL
   DEPENDS model_gen_cmd

--- a/buoy_description/hooks/buoy_description.dsv.in
+++ b/buoy_description/hooks/buoy_description.dsv.in
@@ -1,1 +1,2 @@
 prepend-non-duplicate;IGN_GAZEBO_RESOURCE_PATH;share
+prepend-non-duplicate;IGN_GAZEBO_RESOURCE_PATH;share/buoy_description/models

--- a/buoy_description/models/mbari_wec_base/model.config
+++ b/buoy_description/models/mbari_wec_base/model.config
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <model>
-  <name>MBARI_WEC</name>
+  <name>MBARI_WEC_BASE</name>
   <version>1.0</version>
   <sdf version="1.8">model.sdf</sdf>
 

--- a/buoy_description/models/mbari_wec_ros/model.config
+++ b/buoy_description/models/mbari_wec_ros/model.config
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <model>
-  <name>MBARI_WEC</name>
+  <name>MBARI_WEC_ROS</name>
   <version>1.0</version>
   <sdf version="1.8">model.sdf</sdf>
 

--- a/buoy_description/models/mbari_wec_ros/model.sdf
+++ b/buoy_description/models/mbari_wec_ros/model.sdf
@@ -36,27 +36,27 @@
       <publish_rate>10</publish_rate>
     </plugin>
 
-      <plugin
-        filename="ignition-gazebo-joint-state-publisher-system"
-        name="ignition::gazebo::systems::JointStatePublisher">
-      </plugin>
+    <plugin
+      filename="ignition-gazebo-joint-state-publisher-system"
+      name="ignition::gazebo::systems::JointStatePublisher">
+    </plugin>
 
-      <plugin
-        filename="ignition-gazebo-pose-publisher-system"
-        name="ignition::gazebo::systems::PosePublisher">
-        <publish_link_pose>true</publish_link_pose>
-        <use_pose_vector_msg>true</use_pose_vector_msg>
-        <static_publisher>true</static_publisher>
-        <static_update_frequency>1</static_update_frequency>
-      </plugin>
+    <plugin
+      filename="ignition-gazebo-pose-publisher-system"
+      name="ignition::gazebo::systems::PosePublisher">
+      <publish_link_pose>true</publish_link_pose>
+      <use_pose_vector_msg>true</use_pose_vector_msg>
+      <static_publisher>true</static_publisher>
+      <static_update_frequency>1</static_update_frequency>
+    </plugin>
 
-      <plugin
-        filename="ignition-gazebo-odometry-publisher-system"
-        name="ignition::gazebo::systems::OdometryPublisher">
-        <dimensions>3</dimensions>
-        <odom_frame>MBARI_WEC_ROS/odom</odom_frame>
-        <robot_base_frame>MBARI_WEC_ROS</robot_base_frame>
-      </plugin>
+    <plugin
+      filename="ignition-gazebo-odometry-publisher-system"
+      name="ignition::gazebo::systems::OdometryPublisher">
+      <dimensions>3</dimensions>
+      <odom_frame>MBARI_WEC_ROS/odom</odom_frame>
+      <robot_base_frame>MBARI_WEC_ROS</robot_base_frame>
+    </plugin>
 
   </model>
 </sdf>

--- a/buoy_gazebo/CMakeLists.txt
+++ b/buoy_gazebo/CMakeLists.txt
@@ -15,8 +15,9 @@ else()
 endif()
 
 find_package(ament_cmake REQUIRED)
-find_package(rclcpp REQUIRED)
 find_package(buoy_msgs REQUIRED)
+find_package(buoy_description REQUIRED)
+find_package(rclcpp REQUIRED)
 
 find_package(ignition-cmake2 REQUIRED)
 find_package(ignition-plugin1 REQUIRED COMPONENTS register)

--- a/buoy_gazebo/CMakeLists.txt
+++ b/buoy_gazebo/CMakeLists.txt
@@ -15,8 +15,8 @@ else()
 endif()
 
 find_package(ament_cmake REQUIRED)
-find_package(buoy_msgs REQUIRED)
 find_package(buoy_description REQUIRED)
+find_package(buoy_msgs REQUIRED)
 find_package(rclcpp REQUIRED)
 
 find_package(ignition-cmake2 REQUIRED)

--- a/buoy_gazebo/worlds/buoy_no_plugins.sdf
+++ b/buoy_gazebo/worlds/buoy_no_plugins.sdf
@@ -18,7 +18,7 @@
 
     <include>
       <pose>0 0 0 0 0 0</pose>
-      <uri>buoy</uri>
+      <uri>package://buoy_description/models/mbari_wec_base</uri>
     </include>
 
   </world>


### PR DESCRIPTION
- Bug fix for robot_state_publisher dying, unable to find the model after reorganization.
 ```
Error [SDF.cc:160] Tried to use callback in sdf::findFile(), but the callback is empty.  Did you call sdf::setFindCallback()?
Error Code 13: [/sdf/world[@name="world_demo"]/model[@name="MBARI_WEC_ROS"]/include[0]/uri:/home/anderson/wec/igngzb/openrobotics/workspace/src/buoy_sim/buoy_gazebo/worlds/mbari_wec.sdf:L49]: Msg: Unable to find 
```
- Updating other worlds, launch files and making sure they work as expected.

