### PR TITLE
Fix flaky PC commands test

### DIFF
--- a/.github/workflows/build-and-test.sh
+++ b/.github/workflows/build-and-test.sh
@@ -51,7 +51,5 @@ colcon build --packages-up-to buoy_tests --event-handlers console_direct+
 source $COLCON_WS/install/setup.bash
 
 # Test all buoy packages
-#colcon test --packages-select-regex=buoy --packages-skip=buoy_msgs --event-handlers console_direct+
-launch_test install/buoy_tests/share/buoy_tests/launch/pc_commands_ros_feedback.launch.py
-
+colcon test --packages-select-regex=buoy --packages-skip=buoy_msgs --event-handlers console_direct+
 colcon test-result

--- a/.github/workflows/build-and-test.sh
+++ b/.github/workflows/build-and-test.sh
@@ -51,5 +51,7 @@ colcon build --packages-up-to buoy_tests --event-handlers console_direct+
 source $COLCON_WS/install/setup.bash
 
 # Test all buoy packages
-colcon test --packages-select-regex=buoy --packages-skip=buoy_msgs --event-handlers console_direct+
+#colcon test --packages-select-regex=buoy --packages-skip=buoy_msgs --event-handlers console_direct+
+launch_test install/buoy_tests/share/buoy_tests/launch/pc_commands_ros_feedback.launch.py
+
 colcon test-result

--- a/buoy_tests/tests/fixture_server.cpp
+++ b/buoy_tests/tests/fixture_server.cpp
@@ -109,7 +109,7 @@ TEST(BuoyTests, RunServer)
         response->success = true;
         return;
       } else {
-        RCLCPP_INFO_STREAM(
+        RCLCPP_DEBUG_STREAM(
           rclcpp::get_logger("run_server"),
           "Incoming request\niterations: " << request->iterations);
       }
@@ -123,7 +123,7 @@ TEST(BuoyTests, RunServer)
 
       EXPECT_EQ(iterations - initial_iterations, request->iterations);
 
-      RCLCPP_INFO_STREAM(
+      RCLCPP_DEBUG_STREAM(
         rclcpp::get_logger("run_server"),
         "Response: " << std::boolalpha << response->success << std::noboolalpha);
     }

--- a/buoy_tests/tests/pc_commands_ros_feedback.cpp
+++ b/buoy_tests/tests/pc_commands_ros_feedback.cpp
@@ -309,7 +309,7 @@ TEST_F(BuoyPCTests, PCCommandsInROSFeedback)
 
   // Now send wind curr command
   node->pc_wind_curr_response_future_ = node->send_pc_wind_curr_command(wc);
-  ASSERT_TRUE(node->pc_wind_curr_response_future_.valid());
+  EXPECT_TRUE(node->pc_wind_curr_response_future_.valid()) << "Winding Current future invalid!";
   node->pc_wind_curr_response_future_.wait();
   EXPECT_EQ(
     node->pc_wind_curr_response_future_.get()->result.value,
@@ -334,7 +334,7 @@ TEST_F(BuoyPCTests, PCCommandsInROSFeedback)
 
   // Now send scale command
   node->pc_scale_response_future_ = node->send_pc_scale_command(scale);
-  ASSERT_TRUE(node->pc_scale_response_future_.valid());
+  EXPECT_TRUE(node->pc_scale_response_future_.valid()) << "Scale future invalid!";
   node->pc_scale_response_future_.wait();
   EXPECT_EQ(
     node->pc_scale_response_future_.get()->result.value,
@@ -359,7 +359,7 @@ TEST_F(BuoyPCTests, PCCommandsInROSFeedback)
 
   // Now send retract command
   node->pc_retract_response_future_ = node->send_pc_retract_command(retract);
-  ASSERT_TRUE(node->pc_retract_response_future_.valid());
+  EXPECT_TRUE(node->pc_retract_response_future_.valid()) << "Retract future invalid!";
   node->pc_retract_response_future_.wait();
   EXPECT_EQ(
     node->pc_retract_response_future_.get()->result.value,
@@ -408,7 +408,7 @@ TEST_F(BuoyPCTests, PCCommandsInROSFeedback)
 
   // Now send bias curr command
   node->pc_bias_curr_response_future_ = node->send_pc_bias_curr_command(bc);
-  ASSERT_TRUE(node->pc_bias_curr_response_future_.valid());
+  EXPECT_TRUE(node->pc_bias_curr_response_future_.valid()) << "Bias Current future invalid!";
   node->pc_bias_curr_response_future_.wait();
   EXPECT_EQ(
     node->pc_bias_curr_response_future_.get()->result.value,


### PR DESCRIPTION
I changed some asserts to expects which I think was causing it to bomb out early and then timeout when launch_test didn't notice it exited.